### PR TITLE
feat: client accounts page, shared portal layout, and UX improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import AccountDetailPage from './pages/AccountDetailPage'
 import NewAccountPage from './pages/NewAccountPage'
 import ClientLoginPage from './pages/ClientLoginPage'
 import ClientHomePage from './pages/ClientHomePage'
+import ClientAccountsOverviewPage from './pages/ClientAccountsOverviewPage'
 import SetPasswordPage from './pages/SetPasswordPage'
 import ResetPasswordPage from './pages/ResetPasswordPage'
 import NotFoundPage from './pages/NotFoundPage'
@@ -60,6 +61,7 @@ function App() {
           {/* Client portal — full-screen, no layout */}
           <Route path="/client/login" element={<ClientLoginPage />} />
           <Route path="/client" element={<ClientHomePage />} />
+          <Route path="/client/accounts" element={<ClientAccountsOverviewPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/layouts/ClientPortalLayout.jsx
+++ b/src/layouts/ClientPortalLayout.jsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
+import { useTheme } from '../context/ThemeContext'
+import { useClientAuth } from '../context/ClientAuthContext'
+
+const NAV_ITEMS = [
+  { label: 'Home',      href: '/client',           icon: 'M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z' },
+  { label: 'Accounts',  href: '/client/accounts',  icon: 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z' },
+  { label: 'Payments',  href: '/client/payments',  icon: 'M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z' },
+  { label: 'Transfers', href: '/client/transfers', icon: 'M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4' },
+  { label: 'Exchange',  href: '/client/exchange',  icon: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15' },
+  { label: 'Cards',     href: '/client/cards',     icon: 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z' },
+  { label: 'Loans',     href: '/client/loans',     icon: 'M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z' },
+]
+
+export default function ClientPortalLayout({ children }) {
+  const { dark, toggle } = useTheme()
+  const { clientUser, clientLogout } = useClientAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+
+  async function handleLogout() {
+    await clientLogout()
+    navigate('/client')
+  }
+
+  const isActive = (href) =>
+    href === '/client' ? location.pathname === '/client' : location.pathname.startsWith(href)
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-white dark:bg-slate-900">
+
+      {/* Sidebar */}
+      <aside className={`${sidebarOpen ? 'w-64' : 'w-16'} shrink-0 flex flex-col transition-[width] duration-500 ease-in-out overflow-hidden bg-slate-100 dark:bg-slate-950 border-r border-slate-100 dark:border-slate-800`}>
+        <div className="flex items-center justify-center h-16 border-b border-slate-100 dark:border-slate-800">
+          <button
+            onClick={() => setSidebarOpen(o => !o)}
+            className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white transition-colors p-2"
+            aria-label="Toggle sidebar"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+        <nav className="flex-1 py-4">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              to={item.href}
+              title={!sidebarOpen ? item.label : undefined}
+              className={`flex items-center gap-3 px-4 py-3 text-sm font-light transition-colors
+                ${isActive(item.href)
+                  ? 'text-violet-700 dark:text-white bg-violet-100 dark:bg-violet-600/25 border-r-2 border-violet-500'
+                  : 'text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/60 dark:hover:bg-slate-800/60'
+                }`}
+            >
+              <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d={item.icon} />
+              </svg>
+              <span className={`whitespace-nowrap transition-opacity duration-300 ${sidebarOpen ? 'opacity-100' : 'opacity-0'}`}>
+                {item.label}
+              </span>
+            </Link>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Right: navbar + content */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <nav className="bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-slate-800 shrink-0">
+          <div className="flex items-center justify-between h-16 px-6">
+            <Link to="/client" className="flex items-center gap-3">
+              <div className="w-7 h-7 border border-violet-500 dark:border-violet-400 flex items-center justify-center">
+                <span className="text-violet-500 dark:text-violet-400 text-xs font-serif font-semibold">A</span>
+              </div>
+              <span className="text-slate-900 dark:text-white font-serif text-lg tracking-widest font-light">
+                Anka<span className="text-violet-600 dark:text-violet-400">Banka</span>
+              </span>
+            </Link>
+            <div className="flex items-center gap-4">
+              {clientUser && (
+                <span className="text-sm text-slate-500 dark:text-slate-400 font-light hidden sm:block">
+                  Welcome back, <span className="text-slate-900 dark:text-white font-medium">{clientUser.firstName} {clientUser.lastName}</span>
+                </span>
+              )}
+              <button onClick={toggle} aria-label="Toggle dark mode" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white transition-colors">
+                {dark ? (
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                  </svg>
+                )}
+              </button>
+              <button
+                onClick={handleLogout}
+                className="px-5 py-2 border border-violet-600 dark:border-violet-400 text-violet-600 dark:text-violet-400 text-xs tracking-widest uppercase font-medium hover:bg-violet-600 dark:hover:bg-violet-500 hover:text-white transition-all duration-200"
+              >
+                Sign Out
+              </button>
+            </div>
+          </div>
+        </nav>
+
+        {/* Page content */}
+        <main className="flex-1 overflow-auto">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ClientAccountsOverviewPage.jsx
+++ b/src/pages/ClientAccountsOverviewPage.jsx
@@ -1,0 +1,111 @@
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../hooks/useWindowTitle'
+import ClientPortalLayout from '../layouts/ClientPortalLayout'
+
+// Mock data — replace with GET /api/accounts/my when backend is ready
+const MOCK_CLIENT_ACCOUNTS = [
+  {
+    id: 1,
+    accountNumber: '265-0000000123456-78',
+    accountName: 'Standard Current',
+    currency: 'RSD',
+    availableBalance: 121_234.00,
+    balance: 123_456.00,
+    type: 'personal',
+    subtype: 'standard',
+    status: 'active',
+  },
+  {
+    id: 2,
+    accountNumber: '265-0000000234567-89',
+    accountName: 'Savings',
+    currency: 'RSD',
+    availableBalance: 45_000.00,
+    balance: 45_000.00,
+    type: 'personal',
+    subtype: 'savings',
+    status: 'active',
+  },
+  {
+    id: 3,
+    accountNumber: '265-0000000345678-90',
+    accountName: 'Foreign Currency',
+    currency: 'EUR',
+    availableBalance: 850.00,
+    balance: 850.00,
+    type: 'personal',
+    subtype: 'standard',
+    status: 'active',
+  },
+]
+
+function fmt(n) {
+  return n.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+export default function ClientAccountsOverviewPage() {
+  useWindowTitle('Accounts | AnkaBanka')
+  const navigate = useNavigate()
+
+  const sorted = [...MOCK_CLIENT_ACCOUNTS].sort((a, b) => b.availableBalance - a.availableBalance)
+
+  return (
+    <ClientPortalLayout>
+      <div className="px-8 py-8 max-w-4xl mx-auto w-full">
+
+        <h1 className="font-serif text-3xl font-light text-slate-900 dark:text-white mb-1">Accounts</h1>
+        <div className="w-8 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+
+        <div className="space-y-3">
+          {sorted.map((account) => (
+            <button
+              key={account.id}
+              onClick={() => navigate(`/client/accounts/${account.id}`)}
+              className="w-full text-left bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-5 hover:border-violet-300 dark:hover:border-violet-700 hover:shadow-sm transition-all group"
+            >
+              <div className="flex items-center justify-between">
+                {/* Left: name + number */}
+                <div>
+                  <div className="flex items-center gap-2 mb-1">
+                    <p className="text-base font-medium text-slate-900 dark:text-white group-hover:text-violet-700 dark:group-hover:text-violet-300 transition-colors">
+                      {account.accountName}
+                    </p>
+                    <span className={`text-xs px-2 py-0.5 rounded-full font-light
+                      ${account.status === 'active'
+                        ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400'
+                        : 'bg-slate-100 dark:bg-slate-800 text-slate-400'
+                      }`}>
+                      {account.status}
+                    </span>
+                  </div>
+                  <p className="text-xs text-slate-400 dark:text-slate-500 font-mono">{account.accountNumber}</p>
+                </div>
+
+                {/* Right: balance */}
+                <div className="text-right">
+                  <p className="text-xs text-slate-400 dark:text-slate-500 mb-1">Available balance</p>
+                  <p className="font-serif text-2xl font-light text-slate-900 dark:text-white">
+                    {fmt(account.availableBalance)}
+                  </p>
+                  <p className="text-xs text-slate-400 dark:text-slate-500">{account.currency}</p>
+                </div>
+              </div>
+
+              {/* Footer: type + chevron */}
+              <div className="flex items-center justify-between mt-4 pt-3 border-t border-slate-100 dark:border-slate-800">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-slate-400 dark:text-slate-500 capitalize">{account.type}</span>
+                  <span className="text-slate-200 dark:text-slate-700">·</span>
+                  <span className="text-xs text-slate-400 dark:text-slate-500 capitalize">{account.subtype}</span>
+                </div>
+                <svg className="w-4 h-4 text-slate-300 dark:text-slate-600 group-hover:text-violet-400 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5l7 7-7 7" />
+                </svg>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/ClientHomePage.jsx
+++ b/src/pages/ClientHomePage.jsx
@@ -89,7 +89,7 @@ export default function ClientHomePage() {
 
       {/* Sidebar — logged-in only */}
       {clientUser && (
-        <aside className={`${sidebarOpen ? 'w-48' : 'w-14'} shrink-0 flex flex-col transition-all duration-300 overflow-hidden bg-slate-100 dark:bg-slate-950 border-r border-slate-200 dark:border-slate-800`}>
+        <aside className={`${sidebarOpen ? 'w-64' : 'w-16'} shrink-0 flex flex-col transition-all duration-300 overflow-hidden bg-slate-100 dark:bg-slate-950 border-r border-slate-200 dark:border-slate-800`}>
           {/* Hamburger */}
           <div className="flex items-center justify-center h-16 border-b border-slate-100 dark:border-slate-800">
             <button
@@ -186,7 +186,8 @@ export default function ClientHomePage() {
       </nav>
 
       {/* Page content */}
-      <main className="flex-1 container mx-auto px-6 py-16 max-w-7xl">
+      <main className="flex-1 overflow-auto">
+        <div className="max-w-5xl mx-auto px-6 py-10 w-full">
         <div className="relative min-h-[520px]">
 
           {/* Blobs */}
@@ -353,6 +354,7 @@ export default function ClientHomePage() {
           </section>
 
         </div>
+        </div> {/* end max-w-5xl centering wrapper */}
       </main>
       </div> {/* end right-side flex column */}
     </div>

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import useWindowTitle from '../hooks/useWindowTitle'
 import { useClients } from '../context/ClientsContext'
 
@@ -46,9 +46,8 @@ export default function ClientsPage() {
 
         {/* Header */}
         <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
-        <div className="flex items-end justify-between mb-3">
+        <div className="mb-3">
           <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white">Clients</h1>
-          <Link to="/admin/clients/new" className="btn-primary">New Client</Link>
         </div>
         <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-10" />
 

--- a/src/pages/NewAccountPage.jsx
+++ b/src/pages/NewAccountPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import useWindowTitle from '../hooks/useWindowTitle'
 import { useAccounts } from '../context/AccountsContext'
 import { useClients } from '../context/ClientsContext'
@@ -17,11 +17,12 @@ const EMPTY_FORM = {
 export default function NewAccountPage() {
   useWindowTitle('New Account | AnkaBanka')
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { addAccount } = useAccounts()
   const { clients, loading: clientsLoading, reload: reloadClients } = useClients()
   const { user } = useAuth()
 
-  const [form, setForm]     = useState(EMPTY_FORM)
+  const [form, setForm]     = useState({ ...EMPTY_FORM, ownerId: searchParams.get('clientId') ?? '' })
   const [errors, setErrors] = useState({})
   const [success, setSuccess] = useState(null)
 
@@ -158,6 +159,17 @@ export default function NewAccountPage() {
                 </select>
               )}
             </Field>
+            <div className="mt-3">
+              <Link
+                to="/admin/clients/new?returnTo=/admin/accounts/new"
+                className="inline-flex items-center gap-1.5 text-xs text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-300 transition-colors"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Create a new client
+              </Link>
+            </div>
           </div>
 
           {/* Account details */}

--- a/src/pages/NewClientPage.jsx
+++ b/src/pages/NewClientPage.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import useWindowTitle from '../hooks/useWindowTitle'
 import { useClients } from '../context/ClientsContext'
 
@@ -20,6 +20,8 @@ const REQUIRED = ['firstName', 'lastName', 'email', 'phoneNumber', 'address', 'd
 export default function NewClientPage() {
   useWindowTitle('New Client | AnkaBanka')
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const returnTo = searchParams.get('returnTo')
   const { clients, addClient } = useClients()
 
   const [form, setForm]     = useState(EMPTY_FORM)
@@ -84,18 +86,29 @@ export default function NewClientPage() {
               A welcome email has been sent to <span className="font-medium text-slate-700 dark:text-slate-300">{success.email}</span>.
             </p>
             <div className="flex gap-3 justify-center">
-              <button
-                onClick={() => { setForm(EMPTY_FORM); setSuccess(null) }}
-                className="px-5 py-2 text-xs tracking-widest uppercase border border-violet-600 dark:border-violet-400 text-violet-600 dark:text-violet-400 hover:bg-violet-600 dark:hover:bg-violet-500 hover:text-white rounded-lg transition-colors"
-              >
-                New Client
-              </button>
-              <button
-                onClick={() => navigate('/admin/clients')}
-                className="px-5 py-2 text-xs tracking-widest uppercase bg-violet-600 hover:bg-violet-700 text-white rounded-lg transition-colors"
-              >
-                All Clients
-              </button>
+              {returnTo ? (
+                <button
+                  onClick={() => navigate(`${returnTo}?clientId=${success.id}`)}
+                  className="px-5 py-2 text-xs tracking-widest uppercase bg-violet-600 hover:bg-violet-700 text-white rounded-lg transition-colors"
+                >
+                  Create Account
+                </button>
+              ) : (
+                <>
+                  <button
+                    onClick={() => { setForm(EMPTY_FORM); setSuccess(null) }}
+                    className="px-5 py-2 text-xs tracking-widest uppercase border border-violet-600 dark:border-violet-400 text-violet-600 dark:text-violet-400 hover:bg-violet-600 dark:hover:bg-violet-500 hover:text-white rounded-lg transition-colors"
+                  >
+                    New Client
+                  </button>
+                  <button
+                    onClick={() => navigate('/admin/clients')}
+                    className="px-5 py-2 text-xs tracking-widest uppercase bg-violet-600 hover:bg-violet-700 text-white rounded-lg transition-colors"
+                  >
+                    All Clients
+                  </button>
+                </>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Add ClientPortalLayout with sidebar nav, active route highlighting, theme-aware
- Add ClientAccountsOverviewPage (issue #19): account cards sorted by available balance desc
- Remove "New Client" button from employee ClientsPage (creation only via account flow)
- Add "Create a new client" link on NewAccountPage with returnTo flow
- NewClientPage returns to NewAccountPage with client pre-selected after creation
- Center main content on home and accounts pages
- Widen sidebar from w-48 to w-64
- #19 