### PR TITLE
feat: account carousel on client home dashboard (issue #20 #21)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import NewAccountPage from './pages/NewAccountPage'
 import ClientLoginPage from './pages/ClientLoginPage'
 import ClientHomePage from './pages/ClientHomePage'
 import ClientAccountsOverviewPage from './pages/ClientAccountsOverviewPage'
+import ClientAccountDetailPage from './pages/ClientAccountDetailPage'
 import SetPasswordPage from './pages/SetPasswordPage'
 import ResetPasswordPage from './pages/ResetPasswordPage'
 import NotFoundPage from './pages/NotFoundPage'
@@ -62,6 +63,7 @@ function App() {
           <Route path="/client/login" element={<ClientLoginPage />} />
           <Route path="/client" element={<ClientHomePage />} />
           <Route path="/client/accounts" element={<ClientAccountsOverviewPage />} />
+          <Route path="/client/accounts/:id" element={<ClientAccountDetailPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/pages/ClientAccountDetailPage.jsx
+++ b/src/pages/ClientAccountDetailPage.jsx
@@ -1,0 +1,232 @@
+import { useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import useWindowTitle from '../hooks/useWindowTitle'
+import ClientPortalLayout from '../layouts/ClientPortalLayout'
+import { useClientAuth } from '../context/ClientAuthContext'
+
+// Mock data — replace with GET /api/accounts/{accountId}
+const MOCK_CLIENT_ACCOUNTS = [
+  {
+    id: 1,
+    accountNumber: '265-0000000123456-78',
+    accountName: 'Standard Current',
+    currency: 'RSD',
+    balance: 123_456.00,
+    availableBalance: 121_234.00,
+    type: 'personal',
+    subtype: 'standard',
+    status: 'active',
+    dailyLimit: 250_000.00,
+    monthlyLimit: 1_000_000.00,
+    dailySpending: 2_222.00,
+    monthlySpending: 18_450.00,
+  },
+  {
+    id: 2,
+    accountNumber: '265-0000000234567-89',
+    accountName: 'Savings',
+    currency: 'RSD',
+    balance: 45_000.00,
+    availableBalance: 45_000.00,
+    type: 'personal',
+    subtype: 'savings',
+    status: 'active',
+    dailyLimit: 100_000.00,
+    monthlyLimit: 500_000.00,
+    dailySpending: 0,
+    monthlySpending: 0,
+  },
+  {
+    id: 3,
+    accountNumber: '265-0000000345678-90',
+    accountName: 'Foreign Currency',
+    currency: 'EUR',
+    balance: 850.00,
+    availableBalance: 850.00,
+    type: 'personal',
+    subtype: 'standard',
+    status: 'active',
+    dailyLimit: 5_000.00,
+    monthlyLimit: 20_000.00,
+    dailySpending: 0,
+    monthlySpending: 120.00,
+  },
+]
+
+function fmt(n, currency) {
+  return n.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + (currency ? ` ${currency}` : '')
+}
+
+function Row({ label, value, highlight }) {
+  return (
+    <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
+      <span className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">{label}</span>
+      <span className={`text-sm font-light ${highlight ? 'text-emerald-600 dark:text-emerald-400 font-medium' : 'text-slate-900 dark:text-white'}`}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function Card({ title, children }) {
+  return (
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-6">
+      {title && <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">{title}</p>}
+      {children}
+    </div>
+  )
+}
+
+export default function ClientAccountDetailPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { clientUser } = useClientAuth()
+
+  const account = MOCK_CLIENT_ACCOUNTS.find((a) => a.id === Number(id))
+
+  const [accountName, setAccountName] = useState(account?.accountName ?? '')
+  const [editingName, setEditingName] = useState(false)
+  const [nameInput, setNameInput] = useState(accountName)
+
+  useWindowTitle(account ? `${accountName} | AnkaBanka` : 'Account | AnkaBanka')
+
+  if (!account) {
+    return (
+      <ClientPortalLayout>
+        <div className="px-8 py-8 max-w-3xl mx-auto w-full">
+          <p className="text-slate-500 dark:text-slate-400">Account not found.</p>
+        </div>
+      </ClientPortalLayout>
+    )
+  }
+
+  const reserved = account.balance - account.availableBalance
+
+  function saveName() {
+    if (nameInput.trim()) setAccountName(nameInput.trim())
+    setEditingName(false)
+  }
+
+  return (
+    <ClientPortalLayout>
+      <div className="px-8 py-8 max-w-3xl mx-auto w-full space-y-6">
+
+        {/* Back */}
+        <button
+          onClick={() => navigate('/client/accounts')}
+          className="inline-flex items-center gap-2 text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 hover:text-violet-600 dark:hover:text-violet-400 transition-colors"
+        >
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          All Accounts
+        </button>
+
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            {/* Editable account name */}
+            {editingName ? (
+              <div className="flex items-center gap-2 mb-1">
+                <input
+                  autoFocus
+                  value={nameInput}
+                  onChange={(e) => setNameInput(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') saveName(); if (e.key === 'Escape') setEditingName(false) }}
+                  className="input-field text-2xl font-serif font-light py-1 px-2 max-w-xs"
+                />
+                <button onClick={saveName} className="text-violet-600 dark:text-violet-400 hover:text-violet-800 transition-colors">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                </button>
+                <button onClick={() => setEditingName(false)} className="text-slate-400 hover:text-slate-600 transition-colors">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 mb-1">
+                <h1 className="font-serif text-3xl font-light text-slate-900 dark:text-white">{accountName}</h1>
+                <button
+                  onClick={() => { setNameInput(accountName); setEditingName(true) }}
+                  className="text-slate-300 dark:text-slate-600 hover:text-violet-500 dark:hover:text-violet-400 transition-colors mt-1"
+                  title="Change account name"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                </button>
+              </div>
+            )}
+            <p className="text-xs font-mono text-slate-400 dark:text-slate-500">{account.accountNumber}</p>
+          </div>
+          <span className={`mt-1 shrink-0 text-xs px-3 py-1 rounded-full font-light
+            ${account.status === 'active'
+              ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400'
+              : 'bg-slate-100 dark:bg-slate-800 text-slate-400'
+            }`}>
+            {account.status}
+          </span>
+        </div>
+
+        <div className="w-8 h-px bg-violet-500 dark:bg-violet-400" />
+
+        {/* Action buttons */}
+        <div className="flex flex-wrap gap-3">
+          <button
+            onClick={() => { setNameInput(accountName); setEditingName(true) }}
+            className="inline-flex items-center gap-2 px-4 py-2 text-xs tracking-widest uppercase border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:border-violet-400 dark:hover:border-violet-500 hover:text-violet-600 dark:hover:text-violet-400 rounded-lg transition-all"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+            Change Name
+          </button>
+          <button
+            onClick={() => navigate('/client/payments')}
+            className="inline-flex items-center gap-2 px-4 py-2 text-xs tracking-widest uppercase border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:border-violet-400 dark:hover:border-violet-500 hover:text-violet-600 dark:hover:text-violet-400 rounded-lg transition-all"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+            New Payment
+          </button>
+          <button
+            onClick={() => navigate('/client/transfers')}
+            className="inline-flex items-center gap-2 px-4 py-2 text-xs tracking-widest uppercase border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:border-violet-400 dark:hover:border-violet-500 hover:text-violet-600 dark:hover:text-violet-400 rounded-lg transition-all"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+            </svg>
+            Transfer
+          </button>
+        </div>
+
+        {/* Balance */}
+        <Card title="Balance">
+          <Row label="Available balance" value={fmt(account.availableBalance, account.currency)} highlight />
+          <Row label="Total balance"     value={fmt(account.balance, account.currency)} />
+          <Row label="Reserved funds"    value={fmt(reserved, account.currency)} />
+        </Card>
+
+        {/* Account info */}
+        <Card title="Account info">
+          <Row label="Owner"    value={clientUser ? `${clientUser.firstName} ${clientUser.lastName}` : '—'} />
+          <Row label="Currency" value={account.currency} />
+          <Row label="Type"     value={`${account.type} · ${account.subtype}`} />
+        </Card>
+
+        {/* Limits & spending */}
+        <Card title="Limits & spending">
+          <Row label="Daily limit"     value={fmt(account.dailyLimit, account.currency)} />
+          <Row label="Monthly limit"   value={fmt(account.monthlyLimit, account.currency)} />
+          <Row label="Spent today"     value={fmt(account.dailySpending, account.currency)} />
+          <Row label="Spent this month"value={fmt(account.monthlySpending, account.currency)} />
+        </Card>
+
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/ClientHomePage.jsx
+++ b/src/pages/ClientHomePage.jsx
@@ -6,12 +6,32 @@ import { useClientAuth } from '../context/ClientAuthContext'
 
 // ─── Mock data (swap for real API calls later) ────────────────────────────────
 
-const MOCK_ACCOUNT = {
-  accountNumber: '265-0000000123456-78',
-  availableBalance: 121_234.00,
-  balance: 123_456.00,
-  currency: 'RSD',
-}
+const MOCK_CLIENT_ACCOUNTS = [
+  {
+    id: 1,
+    accountNumber: '265-0000000123456-78',
+    accountName: 'Standard Current',
+    currency: 'RSD',
+    balance: 123_456.00,
+    availableBalance: 121_234.00,
+  },
+  {
+    id: 2,
+    accountNumber: '265-0000000234567-89',
+    accountName: 'Savings',
+    currency: 'RSD',
+    balance: 45_000.00,
+    availableBalance: 45_000.00,
+  },
+  {
+    id: 3,
+    accountNumber: '265-0000000345678-90',
+    accountName: 'Foreign Currency',
+    currency: 'EUR',
+    balance: 850.00,
+    availableBalance: 850.00,
+  },
+]
 
 const MOCK_TRANSACTIONS = [
   { id: 1, description: 'Coffee Shop',      amount: -350,   date: '2026-03-14' },
@@ -43,6 +63,134 @@ function fmt(n) {
   return n.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 }
 
+function BalanceCarousel({ accounts }) {
+  const multi = accounts.length > 1
+  const [index, setIndex] = useState(0)
+  const [cardHovered, setCardHovered] = useState(false)
+  const [nameHovered, setNameHovered] = useState(false)
+  const [editingName, setEditingName] = useState(false)
+  const [nameInput, setNameInput] = useState('')
+  const [names, setNames] = useState(() =>
+    Object.fromEntries(accounts.map((a) => [a.id, a.accountName]))
+  )
+
+  const acct = accounts[index]
+  const currentName = names[acct.id]
+
+  function saveName() {
+    if (nameInput.trim()) setNames((prev) => ({ ...prev, [acct.id]: nameInput.trim() }))
+    setEditingName(false)
+  }
+
+  return (
+    <div
+      style={{ gridArea: 'balance' }}
+      className="bg-white/70 dark:bg-slate-900/70 backdrop-blur border border-slate-200 dark:border-slate-700 rounded-xl p-5 select-none flex flex-col"
+      onMouseEnter={() => setCardHovered(true)}
+      onMouseLeave={() => setCardHovered(false)}
+    >
+      {/* Header: label + account name */}
+      <div className="flex items-start justify-between mb-3">
+        <p className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">Balance</p>
+        <div
+          className="flex items-center gap-1 min-w-0"
+          onMouseEnter={() => setNameHovered(true)}
+          onMouseLeave={() => setNameHovered(false)}
+        >
+          {editingName ? (
+            <>
+              <input
+                autoFocus
+                value={nameInput}
+                onChange={(e) => setNameInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') saveName(); if (e.key === 'Escape') setEditingName(false) }}
+                className="input-field text-xs py-0.5 px-1.5 w-28"
+              />
+              <button onClick={saveName} className="text-violet-500 hover:text-violet-700 transition-colors shrink-0">
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </button>
+              <button onClick={() => setEditingName(false)} className="text-slate-400 hover:text-slate-600 transition-colors shrink-0">
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </>
+          ) : (
+            <>
+              <span className="text-xs text-slate-500 dark:text-slate-400 font-light truncate">{currentName}</span>
+              <button
+                onClick={() => { setNameInput(currentName); setEditingName(true) }}
+                className={`text-slate-300 dark:text-slate-600 hover:text-violet-500 dark:hover:text-violet-400 transition-opacity duration-200 shrink-0 ${nameHovered ? 'opacity-100' : 'opacity-0'}`}
+                aria-label="Rename account"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Content + side arrows */}
+      <div className="relative flex-1">
+        {multi && (
+          <button
+            onClick={() => setIndex((i) => (i - 1 + accounts.length) % accounts.length)}
+            className={`group absolute inset-y-0 -left-5 w-8 flex items-center justify-start transition-opacity duration-200 ${cardHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+            aria-label="Previous account"
+          >
+            <svg className="w-2.5 h-2.5 text-slate-300 dark:text-slate-600 group-hover:w-4 group-hover:h-4 group-hover:text-violet-500 dark:group-hover:text-violet-400 transition-all duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+        )}
+
+        <p className="font-serif text-3xl font-light text-slate-900 dark:text-white leading-none">
+          {fmt(acct.availableBalance)}
+        </p>
+        <p className="text-xs text-slate-400 dark:text-slate-500 mt-1 mb-4">{acct.currency} available</p>
+        <div className="pt-3 border-t border-slate-100 dark:border-slate-800">
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            Total <span className="text-slate-600 dark:text-slate-300">{fmt(acct.balance)} {acct.currency}</span>
+          </p>
+          <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5 truncate" title={acct.accountNumber}>
+            {acct.accountNumber}
+          </p>
+        </div>
+
+        {multi && (
+          <button
+            onClick={() => setIndex((i) => (i + 1) % accounts.length)}
+            className={`group absolute inset-y-0 -right-5 w-8 flex items-center justify-end transition-opacity duration-200 ${cardHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+            aria-label="Next account"
+          >
+            <svg className="w-2.5 h-2.5 text-slate-300 dark:text-slate-600 group-hover:w-4 group-hover:h-4 group-hover:text-violet-500 dark:group-hover:text-violet-400 transition-all duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Dots */}
+      {multi && (
+        <div className={`flex justify-center gap-1.5 mt-4 transition-opacity duration-200 ${cardHovered ? 'opacity-100' : 'opacity-0'}`}>
+          {accounts.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setIndex(i)}
+              className={`w-1.5 h-1.5 rounded-full transition-colors duration-200 ${i === index ? 'bg-violet-500 dark:bg-violet-400' : 'bg-slate-300 dark:bg-slate-600 hover:bg-slate-400 dark:hover:bg-slate-500'}`}
+              aria-label={`Account ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ─── Main component ────────────────────────────────────────────────────────────
 
 export default function ClientHomePage() {
@@ -56,6 +204,7 @@ export default function ClientHomePage() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
   useEffect(() => {
+    if (clientUser) return
     const handleMouse = (e) => {
       const cx = window.innerWidth / 2
       const cy = window.innerHeight / 2
@@ -66,7 +215,7 @@ export default function ClientHomePage() {
     }
     window.addEventListener('mousemove', handleMouse)
     return () => window.removeEventListener('mousemove', handleMouse)
-  }, [])
+  }, [clientUser])
 
   async function handleLogout() {
     await clientLogout()
@@ -247,22 +396,8 @@ export default function ClientHomePage() {
                   gap: '1rem',
                 }}>
 
-                  {/* ① Balance — compact top-left */}
-                  <div style={{ gridArea: 'balance' }} className="bg-white/70 dark:bg-slate-900/70 backdrop-blur border border-slate-200 dark:border-slate-700 rounded-xl p-5">
-                    <p className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 mb-4">Balance</p>
-                    <p className="font-serif text-3xl font-light text-slate-900 dark:text-white leading-none">
-                      {fmt(MOCK_ACCOUNT.availableBalance)}
-                    </p>
-                    <p className="text-xs text-slate-400 dark:text-slate-500 mt-1 mb-4">{MOCK_ACCOUNT.currency} available</p>
-                    <div className="pt-3 border-t border-slate-100 dark:border-slate-800">
-                      <p className="text-xs text-slate-400 dark:text-slate-500">
-                        Total <span className="text-slate-600 dark:text-slate-300">{fmt(MOCK_ACCOUNT.balance)} RSD</span>
-                      </p>
-                      <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5 truncate" title={MOCK_ACCOUNT.accountNumber}>
-                        {MOCK_ACCOUNT.accountNumber}
-                      </p>
-                    </div>
-                  </div>
+                  {/* ① Balance carousel */}
+                  <BalanceCarousel accounts={MOCK_CLIENT_ACCOUNTS} />
 
                   {/* ② Recent transactions — tall, spans both left rows */}
                   <div style={{ gridArea: 'transactions' }} className="bg-white/70 dark:bg-slate-900/70 backdrop-blur border border-slate-200 dark:border-slate-700 rounded-xl p-5 flex flex-col">

--- a/src/pages/ClientLoginPage.jsx
+++ b/src/pages/ClientLoginPage.jsx
@@ -52,7 +52,7 @@ export default function ClientLoginPage() {
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center px-6 py-16">
       <div className="w-full max-w-md">
         <div className="text-center mb-10">
-          <Link to="/" className="inline-flex items-center gap-3 mb-8">
+          <Link to="/client" className="inline-flex items-center gap-3 mb-8">
             <div className="w-7 h-7 border border-violet-500 dark:border-violet-400 flex items-center justify-center">
               <span className="text-violet-500 dark:text-violet-400 text-xs font-serif font-semibold">A</span>
             </div>


### PR DESCRIPTION
- Replace single balance card with multi-account carousel
- Arrows on sides fade in on card hover, grow on zone hover
- Dots indicator visible on hover, clickable to jump to account
- Account name in top-right with hover-pencil inline rename
- Extract BalanceCarousel as standalone component
- Guard parallax mousemove listener to logged-out state only
- Add ClientAccountDetailPage with inline name editing and limits
- Fix ClientLoginPage logo link to /client