### PR TITLE
feat: client payments list and transaction detail (issues #22, #23)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,8 @@ import ClientLoginPage from './pages/ClientLoginPage'
 import ClientHomePage from './pages/ClientHomePage'
 import ClientAccountsOverviewPage from './pages/ClientAccountsOverviewPage'
 import ClientAccountDetailPage from './pages/ClientAccountDetailPage'
+import ClientPaymentsPage from './pages/ClientPaymentsPage'
+import ClientPaymentDetailPage from './pages/ClientPaymentDetailPage'
 import SetPasswordPage from './pages/SetPasswordPage'
 import ResetPasswordPage from './pages/ResetPasswordPage'
 import NotFoundPage from './pages/NotFoundPage'
@@ -64,6 +66,8 @@ function App() {
           <Route path="/client" element={<ClientHomePage />} />
           <Route path="/client/accounts" element={<ClientAccountsOverviewPage />} />
           <Route path="/client/accounts/:id" element={<ClientAccountDetailPage />} />
+          <Route path="/client/payments" element={<ClientPaymentsPage />} />
+          <Route path="/client/payments/:id" element={<ClientPaymentDetailPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/mocks/payments.js
+++ b/src/mocks/payments.js
@@ -1,0 +1,17 @@
+import { Payment } from '../models/Payment'
+
+// Mock data — replace with GET /api/payments when backend is ready
+export const MOCK_PAYMENTS = [
+  new Payment({ id: 1,  dateTime: '2026-03-14 09:23', recipient: 'Coffee Shop',        recipientAccount: '265-0000000987654-32', amount: -350,   fee: 0,  currency: 'RSD', status: 'completed',  reference: 'REF-2026-0314-001', purpose: 'Coffee and snacks' }),
+  new Payment({ id: 2,  dateTime: '2026-03-13 08:00', recipient: 'Poslodavac d.o.o.',  recipientAccount: '265-0000000111222-33', amount:  85000, fee: 0,  currency: 'RSD', status: 'completed',  reference: 'REF-2026-0313-001', purpose: 'Monthly salary' }),
+  new Payment({ id: 3,  dateTime: '2026-03-12 11:45', recipient: 'EPS Distribucija',   recipientAccount: '265-0000000444555-66', amount: -4200,  fee: 30, currency: 'RSD', status: 'completed',  reference: 'REF-2026-0312-001', purpose: 'Electricity bill March' }),
+  new Payment({ id: 4,  dateTime: '2026-03-11 14:12', recipient: 'Amazon EU',          recipientAccount: '265-0000000777888-99', amount: -2800,  fee: 50, currency: 'RSD', status: 'completed',  reference: 'REF-2026-0311-001', purpose: 'Online purchase' }),
+  new Payment({ id: 5,  dateTime: '2026-03-10 16:30', recipient: 'Banka bankomat',     recipientAccount: '265-0000000000000-00', amount: -5000,  fee: 0,  currency: 'RSD', status: 'completed',  reference: 'REF-2026-0310-001', purpose: 'ATM withdrawal' }),
+  new Payment({ id: 6,  dateTime: '2026-03-09 10:05', recipient: 'Ivan Petrović',      recipientAccount: '265-0000000321654-12', amount: -12000, fee: 30, currency: 'RSD', status: 'pending',    reference: 'REF-2026-0309-001', purpose: 'Transfer to friend' }),
+  new Payment({ id: 7,  dateTime: '2026-03-08 08:15', recipient: 'Telekom Srbija',     recipientAccount: '265-0000000654321-45', amount: -1490,  fee: 0,  currency: 'RSD', status: 'completed',  reference: 'REF-2026-0308-001', purpose: 'Mobile subscription' }),
+  new Payment({ id: 8,  dateTime: '2026-03-07 19:22', recipient: 'Netflix',            recipientAccount: '265-0000000999111-22', amount: -699,   fee: 0,  currency: 'RSD', status: 'failed',     reference: 'REF-2026-0307-001', purpose: 'Streaming subscription' }),
+  new Payment({ id: 9,  dateTime: '2026-03-06 13:40', recipient: 'Ignjat Nikolić',     recipientAccount: '265-0000000222333-44', amount: -3500,  fee: 30, currency: 'RSD', status: 'completed',  reference: 'REF-2026-0306-001', purpose: 'Shared expenses' }),
+  new Payment({ id: 10, dateTime: '2026-03-05 17:55', recipient: 'Booking.com',        recipientAccount: '265-0000000555666-77', amount: -180,   fee: 2,  currency: 'EUR', status: 'processing', reference: 'REF-2026-0305-001', purpose: 'Hotel reservation' }),
+  new Payment({ id: 11, dateTime: '2026-03-04 12:00', recipient: 'Andrija Jovanović',  recipientAccount: '265-0000000888999-11', amount: -8000,  fee: 30, currency: 'RSD', status: 'completed',  reference: 'REF-2026-0304-001', purpose: 'Rent' }),
+  new Payment({ id: 12, dateTime: '2026-03-03 09:10', recipient: 'Infostud d.o.o.',    recipientAccount: '265-0000000333444-55', amount:  32000, fee: 0,  currency: 'RSD', status: 'completed',  reference: 'REF-2026-0303-001', purpose: 'Freelance payment' }),
+]

--- a/src/models/Payment.js
+++ b/src/models/Payment.js
@@ -1,0 +1,56 @@
+export class Payment {
+  constructor({
+    id,
+    dateTime,
+    recipient,
+    recipientAccount,
+    amount,
+    fee,
+    currency,
+    status,
+    reference,
+    purpose,
+  }) {
+    this.id               = id
+    this.dateTime         = dateTime
+    this.recipient        = recipient
+    this.recipientAccount = recipientAccount
+    this.amount           = amount           ?? 0
+    this.fee              = fee              ?? 0
+    this.currency         = currency         ?? 'RSD'
+    // 'completed' | 'pending' | 'processing' | 'failed'
+    this.status           = status           ?? 'pending'
+    this.reference        = reference
+    this.purpose          = purpose          ?? ''
+  }
+
+  get isCredit() {
+    return this.amount > 0
+  }
+}
+
+export function paymentFromApi(data) {
+  return new Payment({
+    id:               data.id,
+    dateTime:         data.dateTime       ?? data.date_time,
+    recipient:        data.recipient,
+    recipientAccount: data.recipientAccount ?? data.recipient_account,
+    amount:           data.amount,
+    fee:              data.fee,
+    currency:         data.currency,
+    status:           data.status,
+    reference:        data.reference,
+    purpose:          data.purpose,
+  })
+}
+
+// ─── Status helpers ────────────────────────────────────────────────────────────
+
+export const PAYMENT_STATUSES = ['completed', 'pending', 'processing', 'failed']
+
+export const PAYMENT_STATUS_STYLES = {
+  completed:  'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400',
+  pending:    'bg-amber-50 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400',
+  processing: 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400',
+  failed:     'bg-red-50 dark:bg-red-900/30 text-red-500 dark:text-red-400',
+}

--- a/src/pages/ClientPaymentDetailPage.jsx
+++ b/src/pages/ClientPaymentDetailPage.jsx
@@ -1,0 +1,94 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import useWindowTitle from '../hooks/useWindowTitle'
+import ClientPortalLayout from '../layouts/ClientPortalLayout'
+import { MOCK_PAYMENTS } from '../mocks/payments'
+import { PAYMENT_STATUS_STYLES } from '../models/Payment'
+
+function fmt(n) {
+  return n.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function Row({ label, value }) {
+  return (
+    <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
+      <span className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">{label}</span>
+      <span className="text-sm font-light text-slate-900 dark:text-white">{value}</span>
+    </div>
+  )
+}
+
+export default function ClientPaymentDetailPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+
+  const payment = MOCK_PAYMENTS.find((p) => p.id === Number(id))
+
+  useWindowTitle(payment ? `Payment ${payment.reference} | AnkaBanka` : 'Payment | AnkaBanka')
+
+  if (!payment) {
+    return (
+      <ClientPortalLayout>
+        <div className="px-8 py-8 max-w-2xl mx-auto w-full">
+          <p className="text-slate-500 dark:text-slate-400">Payment not found.</p>
+        </div>
+      </ClientPortalLayout>
+    )
+  }
+
+  return (
+    <ClientPortalLayout>
+      <div className="px-8 py-8 max-w-2xl mx-auto w-full space-y-6">
+
+        {/* Back */}
+        <button
+          onClick={() => navigate('/client/payments')}
+          className="inline-flex items-center gap-2 text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 hover:text-violet-600 dark:hover:text-violet-400 transition-colors"
+        >
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          All Payments
+        </button>
+
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="font-serif text-3xl font-light text-slate-900 dark:text-white mb-1">{payment.recipient}</h1>
+            <p className="text-xs font-mono text-slate-400 dark:text-slate-500">{payment.reference}</p>
+          </div>
+          <span className={`mt-1 shrink-0 text-xs px-3 py-1 rounded-full font-light capitalize ${PAYMENT_STATUS_STYLES[payment.status] ?? 'bg-slate-100 text-slate-400'}`}>
+            {payment.status}
+          </span>
+        </div>
+
+        <div className="w-8 h-px bg-violet-500 dark:bg-violet-400" />
+
+        {/* Amount */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-6">
+          <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Amount</p>
+          <p className={`font-serif text-4xl font-light leading-none ${payment.amount > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-900 dark:text-white'}`}>
+            {payment.amount > 0 ? '+' : ''}{fmt(payment.amount)}
+          </p>
+          <p className="text-sm text-slate-400 dark:text-slate-500 mt-2">{payment.currency}</p>
+        </div>
+
+        {/* Details */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-6">
+          <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Details</p>
+          <Row label="Recipient"         value={payment.recipient} />
+          <Row label="Recipient account" value={payment.recipientAccount} />
+          <Row label="Payment purpose"   value={payment.purpose} />
+          <Row label="Reference number"  value={payment.reference} />
+          <Row label="Date & time"       value={payment.dateTime} />
+          <Row label="Fee"               value={payment.fee > 0 ? `${fmt(payment.fee)} ${payment.currency}` : 'No fee'} />
+          <Row label="Status"            value={
+            <span className={`text-xs px-2.5 py-1 rounded-full font-light capitalize ${PAYMENT_STATUS_STYLES[payment.status] ?? 'bg-slate-100 text-slate-400'}`}>
+              {payment.status}
+            </span>
+          } />
+        </div>
+
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/ClientPaymentsPage.jsx
+++ b/src/pages/ClientPaymentsPage.jsx
@@ -1,0 +1,168 @@
+import { useState, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../hooks/useWindowTitle'
+import ClientPortalLayout from '../layouts/ClientPortalLayout'
+import { MOCK_PAYMENTS } from '../mocks/payments'
+import { PAYMENT_STATUSES, PAYMENT_STATUS_STYLES } from '../models/Payment'
+
+const STATUS_OPTIONS = ['all', ...PAYMENT_STATUSES]
+
+function fmt(n) {
+  return n.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function StatusBadge({ status }) {
+  return (
+    <span className={`text-xs px-2.5 py-1 rounded-full font-light capitalize ${PAYMENT_STATUS_STYLES[status] ?? 'bg-slate-100 text-slate-400'}`}>
+      {status}
+    </span>
+  )
+}
+
+export default function ClientPaymentsPage() {
+  useWindowTitle('Payments | AnkaBanka')
+  const navigate = useNavigate()
+
+  const [filterDate,      setFilterDate]      = useState('')
+  const [filterAmountMin, setFilterAmountMin] = useState('')
+  const [filterAmountMax, setFilterAmountMax] = useState('')
+  const [filterStatus,    setFilterStatus]    = useState('all')
+
+  const filtered = useMemo(() => {
+    return MOCK_PAYMENTS.filter((p) => {
+      if (filterDate && !p.dateTime.startsWith(filterDate)) return false
+      if (filterStatus !== 'all' && p.status !== filterStatus) return false
+      const abs = Math.abs(p.amount)
+      if (filterAmountMin !== '' && abs < parseFloat(filterAmountMin)) return false
+      if (filterAmountMax !== '' && abs > parseFloat(filterAmountMax)) return false
+      return true
+    })
+  }, [filterDate, filterAmountMin, filterAmountMax, filterStatus])
+
+  function clearFilters() {
+    setFilterDate('')
+    setFilterAmountMin('')
+    setFilterAmountMax('')
+    setFilterStatus('all')
+  }
+
+  const hasFilters = filterDate || filterAmountMin || filterAmountMax || filterStatus !== 'all'
+
+  return (
+    <ClientPortalLayout>
+      <div className="px-8 py-8 max-w-4xl mx-auto w-full">
+
+        <h1 className="font-serif text-3xl font-light text-slate-900 dark:text-white mb-1">Payments</h1>
+        <div className="w-8 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+
+        {/* Filters */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-5 mb-6">
+          <div className="flex flex-wrap gap-4 items-end">
+            {/* Date */}
+            <div className="flex flex-col gap-1 min-w-[140px]">
+              <label className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">Date</label>
+              <input
+                type="date"
+                value={filterDate}
+                onChange={(e) => setFilterDate(e.target.value)}
+                className="input-field"
+              />
+            </div>
+
+            {/* Amount range */}
+            <div className="flex flex-col gap-1 min-w-[100px]">
+              <label className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">Min amount</label>
+              <input
+                type="number"
+                value={filterAmountMin}
+                onChange={(e) => setFilterAmountMin(e.target.value)}
+                placeholder="0"
+                className="input-field"
+              />
+            </div>
+            <div className="flex flex-col gap-1 min-w-[100px]">
+              <label className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">Max amount</label>
+              <input
+                type="number"
+                value={filterAmountMax}
+                onChange={(e) => setFilterAmountMax(e.target.value)}
+                placeholder="∞"
+                className="input-field"
+              />
+            </div>
+
+            {/* Status */}
+            <div className="flex flex-col gap-1 min-w-[130px]">
+              <label className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">Status</label>
+              <div className="relative">
+                <select
+                  value={filterStatus}
+                  onChange={(e) => setFilterStatus(e.target.value)}
+                  className="input-field appearance-none pr-10"
+                >
+                  {STATUS_OPTIONS.map((s) => (
+                    <option key={s} value={s}>{s === 'all' ? 'All statuses' : s.charAt(0).toUpperCase() + s.slice(1)}</option>
+                  ))}
+                </select>
+                <svg className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 dark:text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />
+                </svg>
+              </div>
+            </div>
+
+            {hasFilters && (
+              <button
+                onClick={clearFilters}
+                className="text-xs tracking-widest uppercase text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 transition-colors pb-2"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl overflow-hidden">
+          {filtered.length === 0 ? (
+            <p className="text-sm text-slate-400 dark:text-slate-500 text-center py-12">No payments match your filters.</p>
+          ) : (
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-slate-100 dark:border-slate-800">
+                  <th className="text-left text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 px-5 py-3 font-normal">Date</th>
+                  <th className="text-left text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 px-5 py-3 font-normal">Recipient</th>
+                  <th className="text-right text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 px-5 py-3 font-normal">Amount</th>
+                  <th className="text-left text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 px-5 py-3 font-normal">Currency</th>
+                  <th className="text-left text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 px-5 py-3 font-normal">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((p, i) => (
+                  <tr
+                    key={p.id}
+                    onClick={() => navigate(`/client/payments/${p.id}`)}
+                    className={`cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors ${i !== filtered.length - 1 ? 'border-b border-slate-100 dark:border-slate-800' : ''}`}
+                  >
+                    <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light whitespace-nowrap">{p.dateTime}</td>
+                    <td className="px-5 py-3.5 text-sm text-slate-900 dark:text-white font-light">{p.recipient}</td>
+                    <td className={`px-5 py-3.5 text-sm font-medium text-right whitespace-nowrap ${p.amount > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-700 dark:text-slate-300'}`}>
+                      {p.amount > 0 ? '+' : ''}{fmt(p.amount)}
+                    </td>
+                    <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light">{p.currency}</td>
+                    <td className="px-5 py-3.5">
+                      <StatusBadge status={p.status} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <p className="text-xs text-slate-400 dark:text-slate-500 mt-3 text-right">
+          {filtered.length} of {MOCK_PAYMENTS.length} payments
+        </p>
+      </div>
+    </ClientPortalLayout>
+  )
+}


### PR DESCRIPTION
- Add Payment model with paymentFromApi mapper and status helpers
- Add payments mock data in src/mocks/payments.js
- ClientPaymentsPage: table with date, recipient, amount, currency, status; filters by date, amount range, and status
- ClientPaymentDetailPage: shows amount, fee, recipient, recipient account, payment purpose, reference number, date & time, status
- Add /client/payments and /client/payments/:id routes