### PR TITLE
feat: success notifications for client portal actions (#34)

### DIFF
--- a/src/context/ApiErrorContext.jsx
+++ b/src/context/ApiErrorContext.jsx
@@ -1,8 +1,32 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 
+const TOAST_DURATION = 5000
+const FADE_DURATION  = 600
+
 const ApiErrorContext = createContext(null)
 
 let nextId = 0
+
+const STYLES = {
+  error: {
+    border: 'border-red-200 dark:border-red-800',
+    label: 'text-red-600 dark:text-red-400',
+    icon: (
+      <svg className="w-4 h-4 mt-0.5 shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      </svg>
+    ),
+  },
+  success: {
+    border: 'border-emerald-200 dark:border-emerald-800',
+    label: 'text-emerald-600 dark:text-emerald-400',
+    icon: (
+      <svg className="w-4 h-4 mt-0.5 shrink-0 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 13l4 4L19 7" />
+      </svg>
+    ),
+  },
+}
 
 export function ApiErrorProvider({ children }) {
   const [toasts, setToasts] = useState([])
@@ -11,18 +35,24 @@ export function ApiErrorProvider({ children }) {
   const dismiss = useCallback((id) => {
     clearTimeout(timers.current[id])
     delete timers.current[id]
-    setToasts((prev) => prev.filter((t) => t.id !== id))
+    // Start fade-out, then remove after animation completes
+    setToasts((prev) => prev.map((t) => t.id === id ? { ...t, fading: true } : t))
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), FADE_DURATION)
   }, [])
 
-  const addToast = useCallback((status, message) => {
+  const addToast = useCallback((message, type = 'error', label = '') => {
     const id = ++nextId
-    setToasts((prev) => [...prev, { id, status, message }])
-    timers.current[id] = setTimeout(() => dismiss(id), 5000)
+    setToasts((prev) => [...prev, { id, message, type, label, fading: false }])
+    timers.current[id] = setTimeout(() => dismiss(id), TOAST_DURATION)
   }, [dismiss])
+
+  const addSuccess = useCallback((message, label = 'Success') => {
+    addToast(message, 'success', label)
+  }, [addToast])
 
   useEffect(() => {
     function handleApiError(e) {
-      addToast(e.detail.status, e.detail.message)
+      addToast(e.detail.message, 'error', `Error ${e.detail.status}`)
     }
     window.addEventListener('api:error', handleApiError)
     return () => window.removeEventListener('api:error', handleApiError)
@@ -34,37 +64,41 @@ export function ApiErrorProvider({ children }) {
   }, [])
 
   return (
-    <ApiErrorContext.Provider value={{ addToast }}>
+    <ApiErrorContext.Provider value={{ addToast, addSuccess }}>
       {children}
       {/* Toast container */}
       <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-3 pointer-events-none">
-        {toasts.map((toast) => (
-          <div
-            key={toast.id}
-            className="pointer-events-auto flex items-start gap-3 w-80 bg-white dark:bg-slate-800 border border-red-200 dark:border-red-800 shadow-lg px-4 py-3"
-          >
-            <svg className="w-4 h-4 mt-0.5 shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
-            </svg>
-            <div className="flex-1 min-w-0">
-              <p className="text-xs font-medium text-red-600 dark:text-red-400 uppercase tracking-wider">
-                Error {toast.status}
-              </p>
-              <p className="text-sm text-slate-700 dark:text-slate-300 font-light mt-0.5">
-                {toast.message}
-              </p>
-            </div>
-            <button
-              onClick={() => dismiss(toast.id)}
-              className="shrink-0 text-slate-400 hover:text-slate-700 dark:hover:text-white transition-colors"
-              aria-label="Dismiss"
+        {toasts.map((toast) => {
+          const s = STYLES[toast.type] ?? STYLES.error
+          return (
+            <div
+              key={toast.id}
+              style={{ transition: `opacity ${FADE_DURATION}ms ease, transform ${FADE_DURATION}ms ease` }}
+              className={`pointer-events-auto flex items-start gap-3 w-96 bg-white dark:bg-slate-800 border ${s.border} shadow-lg px-5 py-6 ${toast.fading ? 'opacity-0 translate-y-2' : 'opacity-100 translate-y-0'}`}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        ))}
+              {s.icon}
+              <div className="flex-1 min-w-0">
+                {toast.label && (
+                  <p className={`text-xs font-medium uppercase tracking-wider ${s.label}`}>
+                    {toast.label}
+                  </p>
+                )}
+                <p className="text-sm text-slate-700 dark:text-slate-300 font-light mt-0.5">
+                  {toast.message}
+                </p>
+              </div>
+              <button
+                onClick={() => dismiss(toast.id)}
+                className="shrink-0 text-slate-400 hover:text-slate-700 dark:hover:text-white transition-colors"
+                aria-label="Dismiss"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          )
+        })}
       </div>
     </ApiErrorContext.Provider>
   )

--- a/src/pages/client/ClientAccountDetailPage.jsx
+++ b/src/pages/client/ClientAccountDetailPage.jsx
@@ -6,6 +6,7 @@ import { useClientAuth } from '../../context/ClientAuthContext'
 import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { fmt } from '../../utils/formatting'
 import Spinner from '../../components/Spinner'
+import { useApiError } from '../../context/ApiErrorContext'
 
 function Row({ label, value, highlight }) {
   return (
@@ -32,6 +33,7 @@ export default function ClientAccountDetailPage() {
   const navigate = useNavigate()
   const { clientUser } = useClientAuth()
   const { accounts, loading } = useClientAccounts()
+  const { addSuccess } = useApiError()
 
   const account = accounts.find((a) => a.id === Number(id))
 
@@ -62,7 +64,10 @@ export default function ClientAccountDetailPage() {
   const reserved = account.balance - account.availableBalance
 
   function saveName() {
-    if (nameInput.trim()) setAccountName(nameInput.trim())
+    if (nameInput.trim()) {
+      setAccountName(nameInput.trim())
+      addSuccess('Account name updated successfully.', 'Saved')
+    }
     setEditingName(false)
   }
 

--- a/src/pages/client/ClientPaymentVerifyPage.jsx
+++ b/src/pages/client/ClientPaymentVerifyPage.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { useApiError } from '../../context/ApiErrorContext'
 
 function fmt(n, currency) {
   return n.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ` ${currency}`
@@ -20,6 +21,7 @@ export default function ClientPaymentVerifyPage() {
   useWindowTitle('Verify Payment | AnkaBanka')
   const navigate = useNavigate()
   const { state } = useLocation()
+  const { addSuccess } = useApiError()
   const [confirmed, setConfirmed] = useState(false)
 
   // If landed here directly without payment data, go back
@@ -125,7 +127,7 @@ export default function ClientPaymentVerifyPage() {
           <p className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 mb-1">Mobile app</p>
           <p className="text-sm text-slate-500 dark:text-slate-400 font-light mb-5">Tap confirm below to simulate the in-app confirmation.</p>
           <button
-            onClick={() => setConfirmed(true)}
+            onClick={() => { setConfirmed(true); addSuccess(`Payment to ${recipientName} has been submitted.`, 'Payment Confirmed') }}
             className="btn-primary px-10"
           >
             Confirm

--- a/src/pages/client/ClientRecipientsPage.jsx
+++ b/src/pages/client/ClientRecipientsPage.jsx
@@ -5,6 +5,7 @@ import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useRecipients } from '../../context/RecipientsContext'
 import { isValidAccountNumber } from '../../models/Recipient'
 import Spinner from '../../components/Spinner'
+import { useApiError } from '../../context/ApiErrorContext'
 
 // ─── Shared form component ────────────────────────────────────────────────────
 
@@ -102,6 +103,7 @@ export default function ClientRecipientsPage() {
   useWindowTitle('Recipients | AnkaBanka')
   const navigate = useNavigate()
   const { recipients, loading, addRecipient, updateRecipient, deleteRecipient, reorderRecipients } = useRecipients()
+  const { addSuccess } = useApiError()
   const [dragIndex, setDragIndex] = useState(null)
   const [dropIndex, setDropIndex] = useState(null)
 
@@ -112,16 +114,20 @@ export default function ClientRecipientsPage() {
   async function handleAdd(fields) {
     await addRecipient(fields)
     setShowAdd(false)
+    addSuccess(`${fields.name} added to recipients.`, 'Recipient Added')
   }
 
   async function handleEdit(fields) {
     await updateRecipient(editTarget.id, fields)
     setEditTarget(null)
+    addSuccess(`${fields.name} updated successfully.`, 'Recipient Updated')
   }
 
   async function handleDelete() {
+    const name = deleteTarget.name
     await deleteRecipient(deleteTarget.id)
     setDeleteTarget(null)
+    addSuccess(`${name} removed from recipients.`, 'Recipient Removed')
   }
 
   function handleDragStart(i) {

--- a/src/pages/client/ClientTransfersPage.jsx
+++ b/src/pages/client/ClientTransfersPage.jsx
@@ -5,6 +5,7 @@ import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { transferService } from '../../services/transferService'
 import { fmt } from '../../utils/formatting'
+import { useApiError } from '../../context/ApiErrorContext'
 
 const EMPTY_FORM = {
   fromAccountId: '',
@@ -26,6 +27,7 @@ export default function ClientTransfersPage() {
   useWindowTitle('Transfer | AnkaBanka')
   const navigate = useNavigate()
   const { accounts, reload: reloadAccounts } = useClientAccounts()
+  const { addSuccess } = useApiError()
 
   const [form, setForm]       = useState(EMPTY_FORM)
   const [errors, setErrors]   = useState({})
@@ -71,6 +73,7 @@ export default function ClientTransfersPage() {
         amount:        parseFloat(form.amount),
       })
       await reloadAccounts()
+      addSuccess(`${fmt(parseFloat(form.amount), fromAccount.currency)} transferred to ${toAccount.accountName}.`, 'Transfer Successful')
       setSuccess({
         from:   fromAccount,
         to:     toAccount,


### PR DESCRIPTION
Extend ApiErrorContext to support success toasts alongside error toasts. Add success notifications for: payment confirmation, transfer, account name change, and recipient add/edit/delete. Toasts fade out smoothly.