### PR TITLE
feat: form validation with onBlur feedback (#35)

### DIFF
--- a/src/pages/client/ClientLoginPage.jsx
+++ b/src/pages/client/ClientLoginPage.jsx
@@ -3,10 +3,13 @@ import { Link, useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClientAuth } from '../../context/ClientAuthContext'
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 function validate(fields) {
   const errors = {}
-  if (!fields.email)    errors.email    = 'Email is required.'
-  if (!fields.password) errors.password = 'Password is required.'
+  if (!fields.email)                    errors.email    = 'Email is required.'
+  else if (!EMAIL_RE.test(fields.email)) errors.email   = 'Please enter a valid email address.'
+  if (!fields.password)                 errors.password = 'Password is required.'
   return errors
 }
 

--- a/src/pages/client/ClientNewPaymentPage.jsx
+++ b/src/pages/client/ClientNewPaymentPage.jsx
@@ -4,6 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { fmt } from '../../utils/formatting'
+import { isValidAccountNumber } from '../../models/Recipient'
 
 const EMPTY_FORM = {
   fromAccountId:    '',
@@ -48,13 +49,22 @@ export default function ClientNewPaymentPage() {
     setErrors((prev) => ({ ...prev, [name]: undefined }))
   }
 
+  function handleBlur(e) {
+    const { name } = e.target
+    const errs = validate()
+    if (errs[name]) setErrors((prev) => ({ ...prev, [name]: errs[name] }))
+  }
+
   function validate() {
     const errs = {}
     if (!form.fromAccountId)    errs.fromAccountId    = 'Please select an account.'
     if (!form.recipientName.trim())    errs.recipientName    = 'Recipient name is required.'
-    if (!form.recipientAccount.trim()) errs.recipientAccount = 'Recipient account number is required.'
-    if (!form.amount)           errs.amount           = 'Amount is required.'
-    else if (parseFloat(form.amount) <= 0) errs.amount = 'Amount must be greater than 0.'
+    if (!form.recipientAccount.trim())                        errs.recipientAccount = 'Recipient account number is required.'
+    else if (!isValidAccountNumber(form.recipientAccount))    errs.recipientAccount = 'Invalid account number format (e.g. 265-0000000000000-00).'
+    if (!form.amount)                                         errs.amount = 'Amount is required.'
+    else if (parseFloat(form.amount) <= 0)                    errs.amount = 'Amount must be greater than 0.'
+    else if (selectedAccount && parseFloat(form.amount) > selectedAccount.availableBalance)
+      errs.amount = `Insufficient funds. Available: ${fmt(selectedAccount.availableBalance, selectedAccount.currency)}`
     if (!form.paymentCode.trim())      errs.paymentCode      = 'Payment code is required.'
     if (!form.purpose.trim())          errs.purpose          = 'Payment purpose is required.'
     return errs
@@ -97,6 +107,7 @@ export default function ClientNewPaymentPage() {
                   name="fromAccountId"
                   value={form.fromAccountId}
                   onChange={handleChange}
+                  onBlur={handleBlur}
                   className={`input-field appearance-none pr-10 ${errors.fromAccountId ? 'input-error' : ''}`}
                 >
                   <option value="">Select account…</option>
@@ -127,6 +138,7 @@ export default function ClientNewPaymentPage() {
                   name="recipientName"
                   value={form.recipientName}
                   onChange={handleChange}
+                  onBlur={handleBlur}
                   placeholder="Full name or company"
                   className={`input-field ${errors.recipientName ? 'input-error' : ''}`}
                 />
@@ -136,6 +148,7 @@ export default function ClientNewPaymentPage() {
                   name="recipientAccount"
                   value={form.recipientAccount}
                   onChange={handleChange}
+                  onBlur={handleBlur}
                   placeholder="265-0000000000000-00"
                   className={`input-field font-mono ${errors.recipientAccount ? 'input-error' : ''}`}
                 />
@@ -154,6 +167,7 @@ export default function ClientNewPaymentPage() {
                     name="amount"
                     value={form.amount}
                     onChange={handleChange}
+                    onBlur={handleBlur}
                     placeholder="0.00"
                     min="0.01"
                     step="0.01"
@@ -170,6 +184,7 @@ export default function ClientNewPaymentPage() {
                     name="paymentCode"
                     value={form.paymentCode}
                     onChange={handleChange}
+                    onBlur={handleBlur}
                     placeholder="289"
                     maxLength={3}
                     className={`input-field font-mono ${errors.paymentCode ? 'input-error' : ''}`}
@@ -190,6 +205,7 @@ export default function ClientNewPaymentPage() {
                   name="purpose"
                   value={form.purpose}
                   onChange={handleChange}
+                  onBlur={handleBlur}
                   placeholder="e.g. Rent, Invoice #123…"
                   className={`input-field ${errors.purpose ? 'input-error' : ''}`}
                 />

--- a/src/pages/client/ClientRecipientsPage.jsx
+++ b/src/pages/client/ClientRecipientsPage.jsx
@@ -19,6 +19,12 @@ function RecipientForm({ initial = { name: '', accountNumber: '' }, onSave, onCa
     setErrors((prev) => ({ ...prev, [name]: undefined }))
   }
 
+  function handleBlur(e) {
+    const { name } = e.target
+    const errs = validate()
+    if (errs[name]) setErrors((prev) => ({ ...prev, [name]: errs[name] }))
+  }
+
   function validate() {
     const errs = {}
     if (!form.name.trim())                        errs.name          = 'Recipient name is required.'
@@ -44,6 +50,7 @@ function RecipientForm({ initial = { name: '', accountNumber: '' }, onSave, onCa
           name="name"
           value={form.name}
           onChange={handleChange}
+          onBlur={handleBlur}
           placeholder="Full name or company"
           className={`input-field ${errors.name ? 'input-error' : ''}`}
         />
@@ -57,6 +64,7 @@ function RecipientForm({ initial = { name: '', accountNumber: '' }, onSave, onCa
           name="accountNumber"
           value={form.accountNumber}
           onChange={handleChange}
+          onBlur={handleBlur}
           placeholder="265-0000000000000-00"
           className={`input-field font-mono ${errors.accountNumber ? 'input-error' : ''}`}
         />

--- a/src/pages/employee/ClientDetailPage.jsx
+++ b/src/pages/employee/ClientDetailPage.jsx
@@ -17,7 +17,7 @@ export default function ClientDetailPage() {
 
   const [editing, setEditing] = useState(false)
   const [form, setForm] = useState({})
-  const [emailError, setEmailError] = useState('')
+  const [fieldErrors, setFieldErrors] = useState({})
 
   if (!client) {
     return (
@@ -41,25 +41,45 @@ export default function ClientDetailPage() {
       username:    client.username,
       active:      client.active,
     })
-    setEmailError('')
+    setFieldErrors({})
     setEditing(true)
+  }
+
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+  function validate() {
+    const errs = {}
+    if (!form.firstName?.trim())  errs.firstName  = 'This field is required.'
+    if (!form.lastName?.trim())   errs.lastName   = 'This field is required.'
+    if (!form.email?.trim())      errs.email      = 'This field is required.'
+    else if (!EMAIL_RE.test(form.email)) errs.email = 'Wrong email format.'
+    else {
+      const duplicate = clients.find(
+        (c) => c.id !== client.id && c.email.toLowerCase() === form.email.trim().toLowerCase()
+      )
+      if (duplicate) errs.email = 'This email is already in use.'
+    }
+    if (!form.username?.trim())   errs.username   = 'This field is required.'
+    if (form.dateOfBirth && new Date(form.dateOfBirth) >= new Date()) errs.dateOfBirth = 'Date of birth cannot be in the future.'
+    return errs
   }
 
   function handleChange(e) {
     const { name, value, type, checked } = e.target
     setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
-    if (name === 'email') setEmailError('')
+    if (fieldErrors[name]) setFieldErrors((prev) => ({ ...prev, [name]: '' }))
+  }
+
+  function handleBlur(e) {
+    const { name } = e.target
+    const errs = validate()
+    if (errs[name]) setFieldErrors((prev) => ({ ...prev, [name]: errs[name] }))
   }
 
   async function handleSave() {
-    const duplicate = clients.find(
-      (c) => c.id !== client.id && c.email.toLowerCase() === form.email.trim().toLowerCase()
-    )
-    if (duplicate) {
-      setEmailError('This email is already in use.')
-      return
-    }
-    setEmailError('')
+    const errs = validate()
+    if (Object.keys(errs).length) { setFieldErrors(errs); return }
+    setFieldErrors({})
     try {
       await updateClient(client.id, form)
       setEditing(false)
@@ -107,22 +127,22 @@ export default function ClientDetailPage() {
           {editing ? (
             <>
               <Section title="Personal">
-                <EditRow label="First Name"    name="firstName"   value={form.firstName}   onChange={handleChange} />
-                <EditRow label="Last Name"     name="lastName"    value={form.lastName}    onChange={handleChange} />
-                <EditRow label="Date of Birth" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange} type="date" />
+                <EditRow label="First Name"    name="firstName"   value={form.firstName}   onChange={handleChange} onBlur={handleBlur} error={fieldErrors.firstName} />
+                <EditRow label="Last Name"     name="lastName"    value={form.lastName}    onChange={handleChange} onBlur={handleBlur} error={fieldErrors.lastName} />
+                <EditRow label="Date of Birth" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange} onBlur={handleBlur} type="date" error={fieldErrors.dateOfBirth} />
                 <SelectRow label="Gender" name="gender" value={form.gender} onChange={handleChange} options={['Male', 'Female', 'Other']} />
                 {/* JMBG is never editable */}
                 <Row label="JMBG" value={client.jmbg} />
               </Section>
 
               <Section title="Contact">
-                <EditRow label="Email"   name="email"       value={form.email}       onChange={handleChange} type="email" error={emailError} />
-                <EditRow label="Phone"   name="phoneNumber" value={form.phoneNumber} onChange={handleChange} />
-                <EditRow label="Address" name="address"     value={form.address}     onChange={handleChange} />
+                <EditRow label="Email"   name="email"       value={form.email}       onChange={handleChange} onBlur={handleBlur} type="email" error={fieldErrors.email} />
+                <EditRow label="Phone"   name="phoneNumber" value={form.phoneNumber} onChange={handleChange} onBlur={handleBlur} />
+                <EditRow label="Address" name="address"     value={form.address}     onChange={handleChange} onBlur={handleBlur} />
               </Section>
 
               <Section title="Account">
-                <EditRow label="Username" name="username" value={form.username} onChange={handleChange} />
+                <EditRow label="Username" name="username" value={form.username} onChange={handleChange} onBlur={handleBlur} error={fieldErrors.username} />
                 <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
                   <span className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400">Active</span>
                   <input
@@ -225,7 +245,7 @@ function Row({ label, value }) {
   )
 }
 
-function EditRow({ label, name, value, onChange, type = 'text', error }) {
+function EditRow({ label, name, value, onChange, onBlur, type = 'text', error }) {
   return (
     <div className="py-2 border-b border-slate-100 dark:border-slate-800 last:border-0">
       <div className="flex items-center justify-between gap-4">
@@ -235,6 +255,7 @@ function EditRow({ label, name, value, onChange, type = 'text', error }) {
           name={name}
           value={value}
           onChange={onChange}
+          onBlur={onBlur}
           className="text-sm text-right bg-transparent border-b border-violet-300 dark:border-violet-600 text-slate-900 dark:text-white focus:outline-none focus:border-violet-500 w-full max-w-xs"
         />
       </div>

--- a/src/pages/employee/EmployeeDetailPage.jsx
+++ b/src/pages/employee/EmployeeDetailPage.jsx
@@ -48,12 +48,35 @@ export default function EmployeeDetailPage() {
     setEditing(true)
   }
 
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+  function validate() {
+    const errs = {}
+    if (!form.firstName?.trim())  errs.firstName  = 'This field is required.'
+    if (!form.lastName?.trim())   errs.lastName   = 'This field is required.'
+    if (!form.email?.trim())      errs.email      = 'This field is required.'
+    else if (!EMAIL_RE.test(form.email)) errs.email = 'Wrong email format.'
+    if (!form.username?.trim())   errs.username   = 'This field is required.'
+    if (!form.position?.trim())   errs.position   = 'This field is required.'
+    if (!form.department?.trim()) errs.department = 'This field is required.'
+    if (!/^\d{13}$/.test(form.jmbg)) errs.jmbg   = 'Must be exactly 13 digits.'
+    if (form.dateOfBirth && new Date(form.dateOfBirth) >= new Date()) errs.dateOfBirth = 'Date of birth cannot be in the future.'
+    return errs
+  }
+
   function handleChange(e) {
     const { name, value, type, checked } = e.target
     setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
+    if (fieldErrors[name]) setFieldErrors((prev) => ({ ...prev, [name]: '' }))
   }
 
-  const [jmbgError, setJmbgError] = useState('')
+  function handleBlur(e) {
+    const { name } = e.target
+    const errs = validate()
+    if (errs[name]) setFieldErrors((prev) => ({ ...prev, [name]: errs[name] }))
+  }
+
+  const [fieldErrors, setFieldErrors] = useState({})
   const [adminConfirm, setAdminConfirm] = useState(false)
   const [pendingAdminValue, setPendingAdminValue] = useState(false)
 
@@ -77,11 +100,9 @@ export default function EmployeeDetailPage() {
   }
 
   async function handleSave() {
-    if (!/^\d{13}$/.test(form.jmbg)) {
-      setJmbgError('Must be exactly 13 digits.')
-      return
-    }
-    setJmbgError('')
+    const errs = validate()
+    if (Object.keys(errs).length) { setFieldErrors(errs); return }
+    setFieldErrors({})
     try {
       await updateEmployee(emp.id, form)
       setEditing(false)
@@ -132,23 +153,23 @@ export default function EmployeeDetailPage() {
           {editing ? (
             <>
               <Section title="Personal">
-                <EditRow label="First Name"    name="firstName"   value={form.firstName}   onChange={handleChange} />
-                <EditRow label="Last Name"     name="lastName"    value={form.lastName}    onChange={handleChange} />
-                <EditRow label="Date of Birth" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange} type="date" />
+                <EditRow label="First Name"    name="firstName"   value={form.firstName}   onChange={handleChange} onBlur={handleBlur} error={fieldErrors.firstName} />
+                <EditRow label="Last Name"     name="lastName"    value={form.lastName}    onChange={handleChange} onBlur={handleBlur} error={fieldErrors.lastName} />
+                <EditRow label="Date of Birth" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange} onBlur={handleBlur} type="date" error={fieldErrors.dateOfBirth} />
                 <SelectRow label="Gender" name="gender" value={form.gender} onChange={handleChange} options={['Male', 'Female', 'Other']} />
-                <EditRow label="JMBG" name="jmbg" value={form.jmbg} onChange={handleChange} maxLength={13} error={jmbgError} />
+                <EditRow label="JMBG" name="jmbg" value={form.jmbg} onChange={handleChange} onBlur={handleBlur} maxLength={13} error={fieldErrors.jmbg} />
               </Section>
 
               <Section title="Contact">
-                <EditRow label="Email"   name="email"       value={form.email}       onChange={handleChange} type="email" />
-                <EditRow label="Phone"   name="phoneNumber" value={form.phoneNumber} onChange={handleChange} />
-                <EditRow label="Address" name="address"     value={form.address}     onChange={handleChange} />
+                <EditRow label="Email"   name="email"       value={form.email}       onChange={handleChange} onBlur={handleBlur} type="email" error={fieldErrors.email} />
+                <EditRow label="Phone"   name="phoneNumber" value={form.phoneNumber} onChange={handleChange} onBlur={handleBlur} />
+                <EditRow label="Address" name="address"     value={form.address}     onChange={handleChange} onBlur={handleBlur} />
               </Section>
 
               <Section title="Employment">
-                <EditRow label="Username"   name="username"   value={form.username}   onChange={handleChange} />
-                <EditRow label="Position"   name="position"   value={form.position}   onChange={handleChange} />
-                <EditRow label="Department" name="department" value={form.department} onChange={handleChange} />
+                <EditRow label="Username"   name="username"   value={form.username}   onChange={handleChange} onBlur={handleBlur} error={fieldErrors.username} />
+                <EditRow label="Position"   name="position"   value={form.position}   onChange={handleChange} onBlur={handleBlur} error={fieldErrors.position} />
+                <EditRow label="Department" name="department" value={form.department} onChange={handleChange} onBlur={handleBlur} error={fieldErrors.department} />
                 <Row label="Employee ID" value={String(emp.id)} />
                 <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
                   <span className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400">Active</span>
@@ -323,7 +344,7 @@ function Row({ label, value }) {
   )
 }
 
-function EditRow({ label, name, value, onChange, type = 'text', maxLength, error }) {
+function EditRow({ label, name, value, onChange, onBlur, type = 'text', maxLength, error }) {
   return (
     <div className="py-2 border-b border-slate-100 dark:border-slate-800 last:border-0">
       <div className="flex items-center justify-between gap-4">
@@ -333,6 +354,7 @@ function EditRow({ label, name, value, onChange, type = 'text', maxLength, error
           name={name}
           value={value}
           onChange={onChange}
+          onBlur={onBlur}
           maxLength={maxLength}
           className="text-sm text-right bg-transparent border-b border-violet-300 dark:border-violet-600 text-slate-900 dark:text-white focus:outline-none focus:border-violet-500 w-full max-w-xs"
         />

--- a/src/pages/employee/EmployeeLoginPage.jsx
+++ b/src/pages/employee/EmployeeLoginPage.jsx
@@ -3,14 +3,13 @@ import { Link, useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 function validate(fields) {
   const errors = {}
-  if (!fields.email) {
-    errors.email = 'Email is required.'
-  }
-  if (!fields.password) {
-    errors.password = 'Password is required.'
-  }
+  if (!fields.email)                     errors.email    = 'Email is required.'
+  else if (!EMAIL_RE.test(fields.email)) errors.email    = 'Please enter a valid email address.'
+  if (!fields.password)                  errors.password = 'Password is required.'
   return errors
 }
 

--- a/src/pages/employee/NewClientPage.jsx
+++ b/src/pages/employee/NewClientPage.jsx
@@ -34,10 +34,18 @@ export default function NewClientPage() {
     setForm((prev) => ({ ...prev, [name]: value }))
   }
 
+  function handleBlur(e) {
+    const { name } = e.target
+    const errs = validate()
+    if (errs[name]) setErrors((prev) => ({ ...prev, [name]: errs[name] }))
+  }
+
   function validate() {
     const errs = {}
     REQUIRED.forEach((f) => { if (!form[f].trim()) errs[f] = 'This field is required.' })
     if (!/^\d{13}$/.test(form.jmbg)) errs.jmbg = 'Must be exactly 13 digits.'
+    if (!errs.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) errs.email = 'Please enter a valid email address.'
+    if (!errs.dateOfBirth && form.dateOfBirth && new Date(form.dateOfBirth) >= new Date()) errs.dateOfBirth = 'Date of birth cannot be in the future.'
     const emailUsed = clients.some(
       (c) => c.email.toLowerCase() === form.email.trim().toLowerCase()
     )
@@ -136,7 +144,7 @@ export default function NewClientPage() {
         <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">New Client</h1>
         <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-10" />
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form onSubmit={handleSubmit} noValidate className="space-y-6">
 
           {/* Personal */}
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
@@ -144,22 +152,22 @@ export default function NewClientPage() {
             <div className="space-y-5">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
                 <Field label="First Name *" error={errors.firstName}>
-                  <input name="firstName" value={form.firstName} onChange={handleChange}
+                  <input name="firstName" value={form.firstName} onChange={handleChange} onBlur={handleBlur}
                     className={`input-field${errors.firstName ? ' input-error' : ''}`} />
                 </Field>
                 <Field label="Last Name *" error={errors.lastName}>
-                  <input name="lastName" value={form.lastName} onChange={handleChange}
+                  <input name="lastName" value={form.lastName} onChange={handleChange} onBlur={handleBlur}
                     className={`input-field${errors.lastName ? ' input-error' : ''}`} />
                 </Field>
               </div>
               <Field label="JMBG *" error={errors.jmbg}>
-                <input name="jmbg" value={form.jmbg} onChange={handleChange}
+                <input name="jmbg" value={form.jmbg} onChange={handleChange} onBlur={handleBlur}
                   maxLength={13} placeholder="13 digits"
                   className={`input-field font-mono${errors.jmbg ? ' input-error' : ''}`} />
               </Field>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
                 <Field label="Date of Birth *" error={errors.dateOfBirth}>
-                  <input type="date" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange}
+                  <input type="date" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange} onBlur={handleBlur}
                     className={`input-field${errors.dateOfBirth ? ' input-error' : ''}`} />
                 </Field>
                 <Field label="Gender *">
@@ -183,16 +191,16 @@ export default function NewClientPage() {
             <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-6">Contact</p>
             <div className="space-y-5">
               <Field label="Email *" error={errors.email}>
-                <input type="email" name="email" value={form.email} onChange={handleChange}
+                <input type="email" name="email" value={form.email} onChange={handleChange} onBlur={handleBlur}
                   className={`input-field${errors.email ? ' input-error' : ''}`} />
               </Field>
               <Field label="Phone Number *" error={errors.phoneNumber}>
-                <input name="phoneNumber" value={form.phoneNumber} onChange={handleChange}
+                <input name="phoneNumber" value={form.phoneNumber} onChange={handleChange} onBlur={handleBlur}
                   placeholder="+381…"
                   className={`input-field${errors.phoneNumber ? ' input-error' : ''}`} />
               </Field>
               <Field label="Address *" error={errors.address}>
-                <input name="address" value={form.address} onChange={handleChange}
+                <input name="address" value={form.address} onChange={handleChange} onBlur={handleBlur}
                   className={`input-field${errors.address ? ' input-error' : ''}`} />
               </Field>
             </div>
@@ -202,7 +210,7 @@ export default function NewClientPage() {
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
             <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-6">Account</p>
             <Field label="Username *" error={errors.username}>
-              <input name="username" value={form.username} onChange={handleChange}
+              <input name="username" value={form.username} onChange={handleChange} onBlur={handleBlur}
                 className={`input-field${errors.username ? ' input-error' : ''}`} />
             </Field>
           </div>

--- a/src/pages/employee/NewEmployeePage.jsx
+++ b/src/pages/employee/NewEmployeePage.jsx
@@ -35,12 +35,20 @@ export default function NewEmployeePage() {
     if (errors[name]) setErrors((prev) => ({ ...prev, [name]: false }))
   }
 
+  function handleBlur(e) {
+    const { name } = e.target
+    const errs = validate()
+    if (errs[name]) setErrors((prev) => ({ ...prev, [name]: errs[name] }))
+  }
+
   function validate() {
     const next = {}
     REQUIRED.forEach((field) => {
       if (!form[field].trim()) next[field] = true
     })
     if (!/^\d{13}$/.test(form.jmbg)) next.jmbg = true
+    if (!next.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) next.email = true
+    if (form.dateOfBirth && new Date(form.dateOfBirth) >= new Date()) next.dateOfBirth = true
     return next
   }
 
@@ -89,13 +97,13 @@ export default function NewEmployeePage() {
             <FormSection title="Personal">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <Field label="First Name *" error={errors.firstName}>
-                  <input className={`input-field${errors.firstName ? ' input-error' : ''}`} name="firstName" value={form.firstName} onChange={handleChange} placeholder="First name" />
+                  <input className={`input-field${errors.firstName ? ' input-error' : ''}`} name="firstName" value={form.firstName} onChange={handleChange} onBlur={handleBlur} placeholder="First name" />
                 </Field>
                 <Field label="Last Name *" error={errors.lastName}>
-                  <input className={`input-field${errors.lastName ? ' input-error' : ''}`} name="lastName" value={form.lastName} onChange={handleChange} placeholder="Last name" />
+                  <input className={`input-field${errors.lastName ? ' input-error' : ''}`} name="lastName" value={form.lastName} onChange={handleChange} onBlur={handleBlur} placeholder="Last name" />
                 </Field>
-                <Field label="Date of Birth">
-                  <input className="input-field" type="date" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange} />
+                <Field label="Date of Birth" error={errors.dateOfBirth} errorMsg="Date of birth cannot be in the future.">
+                  <input className={`input-field${errors.dateOfBirth ? ' input-error' : ''}`} type="date" name="dateOfBirth" value={form.dateOfBirth} onChange={handleChange} onBlur={handleBlur} />
                 </Field>
                 <Field label="Gender">
                   <select className="input-field" name="gender" value={form.gender} onChange={handleChange}>
@@ -106,7 +114,7 @@ export default function NewEmployeePage() {
                   </select>
                 </Field>
                 <Field label="JMBG *" error={errors.jmbg} errorMsg="Must be exactly 13 digits.">
-                  <input className={`input-field${errors.jmbg ? ' input-error' : ''}`} name="jmbg" value={form.jmbg} onChange={handleChange} placeholder="13-digit personal ID" maxLength={13} />
+                  <input className={`input-field${errors.jmbg ? ' input-error' : ''}`} name="jmbg" value={form.jmbg} onChange={handleChange} onBlur={handleBlur} placeholder="13-digit personal ID" maxLength={13} />
                 </Field>
               </div>
             </FormSection>
@@ -114,8 +122,8 @@ export default function NewEmployeePage() {
             {/* Contact */}
             <FormSection title="Contact">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <Field label="Email *" error={errors.email}>
-                  <input className={`input-field${errors.email ? ' input-error' : ''}`} type="email" name="email" value={form.email} onChange={handleChange} placeholder="email@ankabanka.com" />
+                <Field label="Email *" error={errors.email} errorMsg="Wrong email format.">
+                  <input className={`input-field${errors.email ? ' input-error' : ''}`} type="email" name="email" value={form.email} onChange={handleChange} onBlur={handleBlur} placeholder="email@ankabanka.com" />
                 </Field>
                 <Field label="Phone">
                   <input className="input-field" name="phoneNumber" value={form.phoneNumber} onChange={handleChange} placeholder="+381..." />
@@ -130,13 +138,13 @@ export default function NewEmployeePage() {
             <FormSection title="Employment">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <Field label="Username *" error={errors.username}>
-                  <input className={`input-field${errors.username ? ' input-error' : ''}`} name="username" value={form.username} onChange={handleChange} placeholder="firstname.lastname" />
+                  <input className={`input-field${errors.username ? ' input-error' : ''}`} name="username" value={form.username} onChange={handleChange} onBlur={handleBlur} placeholder="firstname.lastname" />
                 </Field>
                 <Field label="Position *" error={errors.position}>
-                  <input className={`input-field${errors.position ? ' input-error' : ''}`} name="position" value={form.position} onChange={handleChange} placeholder="e.g. Teller" />
+                  <input className={`input-field${errors.position ? ' input-error' : ''}`} name="position" value={form.position} onChange={handleChange} onBlur={handleBlur} placeholder="e.g. Teller" />
                 </Field>
                 <Field label="Department *" error={errors.department}>
-                  <input className={`input-field${errors.department ? ' input-error' : ''}`} name="department" value={form.department} onChange={handleChange} placeholder="e.g. Retail Banking" />
+                  <input className={`input-field${errors.department ? ' input-error' : ''}`} name="department" value={form.department} onChange={handleChange} onBlur={handleBlur} placeholder="e.g. Retail Banking" />
                 </Field>
               </div>
             </FormSection>


### PR DESCRIPTION
- Add email format, JMBG (13 digits), and date-of-birth (not future) validation across all forms
- Show field errors on blur, not only on submit
- Extend validation to edit flows (ClientDetailPage, EmployeeDetailPage)
- Validate account number format and available balance in ClientNewPaymentPage
- Add noValidate to NewClientPage form to suppress browser native tooltips