### PR TITLE
feat: wire client auth, client CRUD, and add client activation page (…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import ClientAccountsPage from './pages/employee/ClientAccountsPage'
 import AccountDetailPage from './pages/employee/AccountDetailPage'
 import NewAccountPage from './pages/employee/NewAccountPage'
 import ClientLoginPage from './pages/client/ClientLoginPage'
+import ClientActivatePage from './pages/client/ClientActivatePage'
 import ClientHomePage from './pages/client/ClientHomePage'
 import ClientAccountsOverviewPage from './pages/client/ClientAccountsOverviewPage'
 import ClientAccountDetailPage from './pages/client/ClientAccountDetailPage'
@@ -78,6 +79,7 @@ function App() {
 
           {/* Client portal — full-screen, no layout */}
           <Route path="/client/login" element={<ClientLoginPage />} />
+          <Route path="/client/activate" element={<ClientActivatePage />} />
           <Route path="/client" element={<ClientHomePage />} />
           <Route path="/client/accounts" element={<ClientAccountsOverviewPage />} />
           <Route path="/client/accounts/:id" element={<ClientAccountDetailPage />} />

--- a/src/context/ClientAuthContext.jsx
+++ b/src/context/ClientAuthContext.jsx
@@ -1,10 +1,23 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useState, useEffect } from 'react'
 import { clientAuthService } from '../services/clientAuthService'
 
 const ClientAuthContext = createContext()
 
 export function ClientAuthProvider({ children }) {
   const [clientUser, setClientUser] = useState(null)
+
+  // Restore session from stored token on mount.
+  useEffect(() => {
+    const user = clientAuthService.restoreSession()
+    if (user) setClientUser(user)
+  }, [])
+
+  // Listen for forced logout when clientApiClient's token refresh fails.
+  useEffect(() => {
+    function handleExpired() { setClientUser(null) }
+    window.addEventListener('client-auth:session-expired', handleExpired)
+    return () => window.removeEventListener('client-auth:session-expired', handleExpired)
+  }, [])
 
   async function clientLogin(email, password) {
     const userData = await clientAuthService.login(email, password)

--- a/src/models/Client.js
+++ b/src/models/Client.js
@@ -35,16 +35,16 @@ export class Client {
 export function clientFromApi(data) {
   return new Client({
     id:          data.id,
-    firstName:   data.ime,
-    lastName:    data.prezime,
+    firstName:   data.first_name,
+    lastName:    data.last_name,
     jmbg:        data.jmbg,
     email:       data.email,
-    phoneNumber: data.broj_telefona,
-    address:     data.adresa,
-    dateOfBirth: data.datum_rodjenja,
-    gender:      data.pol,
+    phoneNumber: data.phone_number,
+    address:     data.address,
+    dateOfBirth: data.date_of_birth,
+    gender:      data.gender,
     username:    data.username,
-    active:      data.aktivan,
-    bankAccounts: data.bank_accounts ?? [],
+    active:      data.active,
+    bankAccounts: [],
   })
 }

--- a/src/pages/client/ClientActivatePage.jsx
+++ b/src/pages/client/ClientActivatePage.jsx
@@ -1,0 +1,221 @@
+import { useState } from 'react'
+import { useSearchParams, Link } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import axios from 'axios'
+
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8081'
+
+const MIN_LENGTH = 8
+const MAX_LENGTH = 32
+const HAS_UPPER  = /[A-Z]/
+const HAS_LOWER  = /[a-z]/
+const TWO_DIGITS = /(?=(.*[0-9]){2})/
+
+function validate(password, confirm) {
+  const errors = {}
+  if (!password) {
+    errors.password = 'Password is required.'
+  } else if (password.length < MIN_LENGTH) {
+    errors.password = `Password must be at least ${MIN_LENGTH} characters.`
+  } else if (password.length > MAX_LENGTH) {
+    errors.password = `Password must be at most ${MAX_LENGTH} characters.`
+  } else if (!HAS_UPPER.test(password)) {
+    errors.password = 'Password must contain at least one uppercase letter.'
+  } else if (!HAS_LOWER.test(password)) {
+    errors.password = 'Password must contain at least one lowercase letter.'
+  } else if (!TWO_DIGITS.test(password)) {
+    errors.password = 'Password must contain at least two numbers.'
+  }
+  if (!confirm) {
+    errors.confirm = 'Please confirm your password.'
+  } else if (password && confirm !== password) {
+    errors.confirm = 'Passwords do not match.'
+  }
+  return errors
+}
+
+export default function ClientActivatePage() {
+  useWindowTitle('Activate Account | AnkaBanka')
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')
+
+  const [fields, setFields]       = useState({ password: '', confirm: '' })
+  const [touched, setTouched]     = useState({ password: false, confirm: false })
+  const [submitted, setSubmitted] = useState(false)
+  const [done, setDone]           = useState(false)
+  const [apiError, setApiError]   = useState(null)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirm,  setShowConfirm]  = useState(false)
+
+  const errors = validate(fields.password, fields.confirm)
+  const visibleErrors = {
+    password: (touched.password || submitted) ? errors.password : undefined,
+    confirm:  (touched.confirm  || submitted) ? errors.confirm  : undefined,
+  }
+
+  function handleChange(e) {
+    setApiError(null)
+    setFields((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  function handleBlur(e) {
+    setTouched((prev) => ({ ...prev, [e.target.name]: true }))
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setSubmitted(true)
+    if (Object.keys(errors).length > 0) return
+    try {
+      await axios.post(`${BASE_URL}/client/activate`, {
+        token,
+        password:         fields.password,
+        confirm_password: fields.confirm,
+      })
+      setDone(true)
+    } catch (err) {
+      const msg = err?.response?.data?.error
+      setApiError(msg ?? 'Something went wrong. The link may have expired.')
+    }
+  }
+
+  /* Missing token */
+  if (!token) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center text-center px-6">
+        <p className="text-xs tracking-widest uppercase text-red-500 mb-4">Invalid Link</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Link not found</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mx-auto mb-6" />
+        <p className="text-slate-500 dark:text-slate-400 font-light mb-10">
+          This activation link is invalid or has already been used.
+        </p>
+        <Link to="/client/login" className="btn-primary">Go to Client Login</Link>
+      </div>
+    )
+  }
+
+  /* Success */
+  if (done) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center text-center px-6">
+        <div className="w-14 h-14 border border-violet-500 dark:border-violet-400 flex items-center justify-center mx-auto mb-8">
+          <svg className="w-6 h-6 text-violet-500 dark:text-violet-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">All Set</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Account Activated</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mx-auto mb-6" />
+        <p className="text-slate-500 dark:text-slate-400 font-light mb-10">
+          Your account is ready. You can now sign in with your email and new password.
+        </p>
+        <Link to="/client/login" className="btn-primary">Sign In</Link>
+      </div>
+    )
+  }
+
+  /* Form */
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center px-6 py-16">
+      <Link to="/client" className="flex items-center gap-3 mb-14">
+        <div className="w-7 h-7 border border-violet-500 dark:border-violet-400 flex items-center justify-center">
+          <span className="text-violet-500 dark:text-violet-400 text-xs font-serif font-semibold">A</span>
+        </div>
+        <span className="text-slate-900 dark:text-white font-serif text-lg tracking-widest font-light">
+          Anka<span className="text-violet-600 dark:text-violet-400">Banka</span>
+        </span>
+      </Link>
+
+      <div className="w-full max-w-md">
+        <div className="text-center mb-10">
+          <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Account Activation</p>
+          <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-2">Create Password</h1>
+          <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mx-auto mb-4" />
+          <p className="text-slate-500 dark:text-slate-400 font-light text-sm">
+            Set a password to activate your banking account.
+          </p>
+        </div>
+
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
+          <form onSubmit={handleSubmit} noValidate className="space-y-6">
+
+            <div>
+              <label htmlFor="password" className="block text-xs tracking-widest uppercase text-slate-600 dark:text-slate-400 mb-2">
+                New Password
+              </label>
+              <div className="relative">
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  value={fields.password}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="8–32 characters"
+                  className={`input-field pr-12 ${visibleErrors.password ? 'input-error' : ''}`}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((p) => !p)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  <EyeIcon show={showPassword} />
+                </button>
+              </div>
+              {visibleErrors.password && <p className="mt-2 text-xs text-red-500">{visibleErrors.password}</p>}
+            </div>
+
+            <div>
+              <label htmlFor="confirm" className="block text-xs tracking-widest uppercase text-slate-600 dark:text-slate-400 mb-2">
+                Confirm Password
+              </label>
+              <div className="relative">
+                <input
+                  id="confirm"
+                  name="confirm"
+                  type={showConfirm ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  value={fields.confirm}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="Repeat password"
+                  className={`input-field pr-12 ${visibleErrors.confirm ? 'input-error' : ''}`}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirm((p) => !p)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+                  aria-label={showConfirm ? 'Hide password' : 'Show password'}
+                >
+                  <EyeIcon show={showConfirm} />
+                </button>
+              </div>
+              {visibleErrors.confirm && <p className="mt-2 text-xs text-red-500">{visibleErrors.confirm}</p>}
+            </div>
+
+            {apiError && <p className="text-xs text-red-500">{apiError}</p>}
+
+            <button type="submit" className="btn-primary w-full">
+              Activate Account
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EyeIcon({ show }) {
+  return show ? (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+    </svg>
+  ) : (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+    </svg>
+  )
+}

--- a/src/services/clientApiClient.js
+++ b/src/services/clientApiClient.js
@@ -1,0 +1,85 @@
+/**
+ * Client API Client
+ *
+ * Axios instance for client-portal API calls.
+ * Uses clientTokenService (separate keys from employee tokens).
+ * On 401, silently refreshes via POST /client/refresh and retries.
+ */
+
+import axios from 'axios'
+import { clientTokenService } from './clientTokenService'
+
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8081'
+
+// Bare client used only for the refresh call — no interceptors to avoid loops.
+export const clientRefreshAxios = axios.create({ baseURL: BASE_URL })
+
+// Main client for all client-portal requests.
+export const clientApiClient = axios.create({ baseURL: BASE_URL })
+
+// ── Request interceptor ───────────────────────────────────────────────────────
+clientApiClient.interceptors.request.use(
+  (config) => {
+    const token = clientTokenService.getAccessToken()
+    if (token) config.headers.Authorization = `Bearer ${token}`
+    return config
+  },
+  (error) => Promise.reject(error)
+)
+
+// ── Response interceptor (silent token refresh) ───────────────────────────────
+let isRefreshing = false
+let waitingQueue = []
+
+function flushQueue(error, token) {
+  waitingQueue.forEach(({ resolve, reject }) =>
+    error ? reject(error) : resolve(token)
+  )
+  waitingQueue = []
+}
+
+clientApiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config
+    const status   = error.response?.status
+
+    if (status !== 401 || original._retry) {
+      return Promise.reject(error)
+    }
+
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        waitingQueue.push({ resolve, reject })
+      }).then((newToken) => {
+        original.headers.Authorization = `Bearer ${newToken}`
+        return clientApiClient(original)
+      })
+    }
+
+    original._retry = true
+    isRefreshing    = true
+
+    try {
+      const refreshToken = clientTokenService.getRefreshToken()
+      if (!refreshToken) throw new Error('No refresh token available.')
+
+      const { data } = await clientRefreshAxios.post('/client/refresh', {
+        refresh_token: refreshToken,
+      })
+
+      clientTokenService.setAccessToken(data.access_token)
+      flushQueue(null, data.access_token)
+
+      original.headers.Authorization = `Bearer ${data.access_token}`
+      return clientApiClient(original)
+    } catch (refreshError) {
+      flushQueue(refreshError, null)
+      clientTokenService.clear()
+      window.dispatchEvent(new CustomEvent('client-auth:session-expired'))
+      return Promise.reject(refreshError)
+    } finally {
+      isRefreshing = false
+    }
+  }
+)

--- a/src/services/clientAuthService.js
+++ b/src/services/clientAuthService.js
@@ -1,38 +1,59 @@
 /**
- * Client Auth Service (mock)
+ * Client Auth Service
  *
- * Authenticates bank clients against the in-memory mock client list.
- * Mock password for every client: "client123"
- *
- * Replace the body of `login` with a real API call once the backend is ready.
+ * Authenticates bank clients via POST /client/login.
+ * Stores tokens in clientTokenService (separate keys from employee tokens).
  */
 
-import { mockClients } from '../mocks/clients'
+import axios from 'axios'
+import { clientTokenService } from './clientTokenService'
 
-const MOCK_PASSWORD = 'client123'
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8081'
+
+function decodeJwtPayload(token) {
+  const payload = token.split('.')[1]
+  return JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')))
+}
 
 export const clientAuthService = {
   async login(email, password) {
-    const client = mockClients.find(
-      (c) => c.email.toLowerCase() === email.trim().toLowerCase()
-    )
-    if (!client || password !== MOCK_PASSWORD) {
-      throw new Error('Invalid email or password.')
-    }
+    const { data } = await axios.post(`${BASE_URL}/client/login`, { email, password })
+
+    clientTokenService.setAccessToken(data.access_token)
+    clientTokenService.setRefreshToken(data.refresh_token)
+
+    const claims = decodeJwtPayload(data.access_token)
     return {
-      id:          client.id,
-      firstName:   client.firstName,
-      lastName:    client.lastName,
-      email:       client.email,
-      phoneNumber: client.phoneNumber,
-      address:     client.address,
-      username:    client.username,
-      dateOfBirth: client.dateOfBirth,
-      gender:      client.gender,
+      id:        claims.user_id,
+      firstName: claims.first_name,
+      lastName:  claims.last_name,
+      email:     claims.email,
     }
   },
 
   async logout() {
-    // nothing to do in mock; clear tokens here when backend is ready
+    clientTokenService.clear()
+  },
+
+  /** Called on app load to restore a previous session from stored tokens. */
+  restoreSession() {
+    const token = clientTokenService.getAccessToken()
+    if (!token) return null
+    try {
+      const claims = decodeJwtPayload(token)
+      if (claims.exp * 1000 < Date.now()) {
+        clientTokenService.clear()
+        return null
+      }
+      return {
+        id:        claims.user_id,
+        firstName: claims.first_name,
+        lastName:  claims.last_name,
+        email:     claims.email,
+      }
+    } catch {
+      clientTokenService.clear()
+      return null
+    }
   },
 }

--- a/src/services/clientService.js
+++ b/src/services/clientService.js
@@ -1,44 +1,47 @@
-import { mockClients } from '../mocks/clients'
-import { Client } from '../models/Client'
-
-// In-memory store so updates persist within a session.
-// Replace the bodies of these functions with real API calls once the backend is ready.
-let _clients = mockClients.map((c) => new Client(c))
-let _nextId = _clients.length + 1
+import { apiClient } from './apiClient'
+import { clientFromApi } from '../models/Client'
 
 export const clientService = {
-  async getClients() {
-    return [..._clients]
+  async getClients({ page = 1, pageSize = 100 } = {}) {
+    const { data } = await apiClient.get('/clients', {
+      params: { page, page_size: pageSize },
+    })
+    return data.clients.map(clientFromApi)
   },
 
   async getClientById(id) {
-    const client = _clients.find((c) => c.id === id)
-    if (!client) throw new Error(`Client ${id} not found`)
-    return { ...client }
+    const { data } = await apiClient.get(`/clients/${id}`)
+    return clientFromApi(data)
   },
 
-  async createClient(data) {
-    const client = new Client({ ...data, id: _nextId++, active: true, bankAccounts: [] })
-    _clients = [..._clients, client]
-    return client
+  async createClient(formData) {
+    const { data } = await apiClient.post('/clients', {
+      first_name:    formData.firstName,
+      last_name:     formData.lastName,
+      jmbg:          formData.jmbg,
+      date_of_birth: formData.dateOfBirth,
+      gender:        formData.gender,
+      email:         formData.email,
+      phone_number:  formData.phoneNumber,
+      address:       formData.address,
+      username:      formData.username,
+    })
+    return clientFromApi(data)
   },
 
   async updateClient(id, fields) {
-    _clients = _clients.map((c) => {
-      if (c.id !== id) return c
-      return new Client({
-        ...c,
-        firstName:   fields.firstName   ?? c.firstName,
-        lastName:    fields.lastName    ?? c.lastName,
-        email:       fields.email       ?? c.email,
-        phoneNumber: fields.phoneNumber ?? c.phoneNumber,
-        address:     fields.address     ?? c.address,
-        dateOfBirth: fields.dateOfBirth ?? c.dateOfBirth,
-        gender:      fields.gender      ?? c.gender,
-        username:    fields.username    ?? c.username,
-        active:      fields.active      ?? c.active,
-      })
+    const { data } = await apiClient.put(`/clients/${id}`, {
+      first_name:    fields.firstName,
+      last_name:     fields.lastName,
+      jmbg:          fields.jmbg,
+      date_of_birth: fields.dateOfBirth,
+      gender:        fields.gender,
+      email:         fields.email,
+      phone_number:  fields.phoneNumber,
+      address:       fields.address,
+      username:      fields.username,
+      active:        fields.active,
     })
-    return _clients.find((c) => c.id === id)
+    return clientFromApi(data)
   },
 }

--- a/src/services/clientTokenService.js
+++ b/src/services/clientTokenService.js
@@ -1,0 +1,22 @@
+/**
+ * Client Token Service
+ *
+ * Separate from tokenService (employee tokens) to avoid key collisions.
+ * Uses 'client_access_token' and 'client_refresh_token' keys in sessionStorage.
+ */
+
+const CLIENT_ACCESS_TOKEN_KEY  = 'client_access_token'
+const CLIENT_REFRESH_TOKEN_KEY = 'client_refresh_token'
+
+export const clientTokenService = {
+  getAccessToken()       { return sessionStorage.getItem(CLIENT_ACCESS_TOKEN_KEY) },
+  setAccessToken(token)  { sessionStorage.setItem(CLIENT_ACCESS_TOKEN_KEY, token) },
+
+  getRefreshToken()      { return sessionStorage.getItem(CLIENT_REFRESH_TOKEN_KEY) },
+  setRefreshToken(token) { sessionStorage.setItem(CLIENT_REFRESH_TOKEN_KEY, token) },
+
+  clear() {
+    sessionStorage.removeItem(CLIENT_ACCESS_TOKEN_KEY)
+    sessionStorage.removeItem(CLIENT_REFRESH_TOKEN_KEY)
+  },
+}


### PR DESCRIPTION
…#57 #62)

- Add clientTokenService with separate sessionStorage keys (client_access_token, client_refresh_token)
- Add clientApiClient with silent token refresh via POST /client/refresh
- Wire clientAuthService to real POST /client/login; decode JWT for user info; session restore on load
- ClientAuthContext listens for client-auth:session-expired to force logout on token failure
- Wire clientService to real API (GET/POST/PUT /clients) using employee token
- Fix clientFromApi field mapping to match actual API response (English snake_case)
- Add ClientActivatePage at /client/activate for new client account setup