### PR TITLE
feat: wire account services to real API (#58 #63)

### DIFF
--- a/src/models/BankAccount.js
+++ b/src/models/BankAccount.js
@@ -85,3 +85,26 @@ export const BUSINESS_SUBTYPES = [
   { value: 'ad',         label: 'AD (Joint Stock)' },
   { value: 'foundation', label: 'Foundation' },
 ]
+
+// Maps a backend account response to a BankAccount instance.
+// Used by both accountService (create response) and clientAccountService (list/detail).
+export function bankAccountFromApi(data) {
+  return new BankAccount({
+    id:               data.id ?? data.accountId,
+    accountNumber:    data.accountNumber,
+    accountName:      data.accountName    ?? null,
+    ownerId:          data.ownerId        ?? null,
+    ownerFirstName:   data.ownerFirstName ?? null,
+    ownerLastName:    data.ownerLastName  ?? null,
+    createdByEmployeeId: data.employeeId  ?? null,
+    currency:         data.currency ?? data.currencyCode ?? 'RSD',
+    type:             data.accountType ? data.accountType.toLowerCase() : null,
+    status:           data.status ? data.status.toLowerCase() : 'active',
+    balance:          data.balance        ?? 0,
+    availableBalance: data.availableBalance ?? 0,
+    dailyLimit:       data.dailyLimit     ?? 250000,
+    monthlyLimit:     data.monthlyLimit   ?? 1000000,
+    dailySpending:    data.dailySpent     ?? 0,
+    monthlySpending:  data.monthlySpent   ?? 0,
+  })
+}

--- a/src/pages/employee/ClientDetailPage.jsx
+++ b/src/pages/employee/ClientDetailPage.jsx
@@ -2,16 +2,20 @@ import { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClients } from '../../context/ClientsContext'
+import { useAccounts } from '../../context/AccountsContext'
 
 export default function ClientDetailPage() {
   const { id } = useParams()
   const { clients, loading, reload, updateClient } = useClients()
+  const { accounts, reload: reloadAccounts } = useAccounts()
 
   useEffect(() => {
     if (clients.length === 0 && !loading) reload()
+    if (accounts.length === 0) reloadAccounts()
   }, [])
 
   const client = clients.find((c) => c.id === Number(id))
+  const clientAccounts = accounts.filter((a) => a.ownerId === Number(id))
 
   useWindowTitle(client ? `${client.fullName} | AnkaBanka` : 'Client | AnkaBanka')
 
@@ -156,11 +160,11 @@ export default function ClientDetailPage() {
               </Section>
 
               <Section title="Bank Accounts">
-                {client.bankAccounts.length === 0 ? (
+                {clientAccounts.length === 0 ? (
                   <p className="text-sm text-slate-400 dark:text-slate-500 py-3">No accounts linked.</p>
                 ) : (
-                  client.bankAccounts.map((acc) => (
-                    <Row key={acc} label="Account" value={acc} />
+                  clientAccounts.map((acc) => (
+                    <Row key={acc.id} label={acc.accountName ?? acc.accountNumber} value={acc.accountNumber} />
                   ))
                 )}
               </Section>
@@ -202,11 +206,11 @@ export default function ClientDetailPage() {
               </Section>
 
               <Section title="Bank Accounts">
-                {client.bankAccounts.length === 0 ? (
+                {clientAccounts.length === 0 ? (
                   <p className="text-sm text-slate-400 dark:text-slate-500 py-3">No accounts linked.</p>
                 ) : (
-                  client.bankAccounts.map((acc) => (
-                    <Row key={acc} label="Account" value={acc} />
+                  clientAccounts.map((acc) => (
+                    <Row key={acc.id} label={acc.accountName ?? acc.accountNumber} value={acc.accountNumber} />
                   ))
                 )}
               </Section>

--- a/src/pages/employee/ClientsPage.jsx
+++ b/src/pages/employee/ClientsPage.jsx
@@ -2,15 +2,17 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClients } from '../../context/ClientsContext'
+import { useAccounts } from '../../context/AccountsContext'
 
 export default function ClientsPage() {
   useWindowTitle('Clients | AnkaBanka')
   const navigate = useNavigate()
   const { clients, loading, error, reload } = useClients()
+  const { accounts, reload: reloadAccounts } = useAccounts()
 
   const [query, setQuery] = useState('')
 
-  useEffect(() => { reload() }, [])
+  useEffect(() => { reload(); reloadAccounts() }, [])
 
   const sorted = [...clients].sort((a, b) => a.lastName.localeCompare(b.lastName, 'sr'))
 
@@ -105,7 +107,14 @@ export default function ClientsPage() {
                         i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
                       }`}
                     >
-                      <td className="px-6 py-4 text-slate-900 dark:text-white font-medium">{client.fullName}</td>
+                      <td className="px-6 py-4 text-slate-900 dark:text-white font-medium">
+                        <span className="flex items-center gap-2">
+                          {client.fullName}
+                          {!accounts.some((a) => a.ownerId === client.id) && (
+                            <span title="No accounts linked" className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-red-500 text-white text-xs font-bold leading-none shrink-0">!</span>
+                          )}
+                        </span>
+                      </td>
                       <td className="px-6 py-4 text-slate-600 dark:text-slate-300">{client.email}</td>
                       <td className="px-6 py-4 text-slate-600 dark:text-slate-300 whitespace-nowrap">{client.phoneNumber}</td>
                       <td className="px-6 py-4">

--- a/src/pages/employee/NewAccountPage.jsx
+++ b/src/pages/employee/NewAccountPage.jsx
@@ -142,11 +142,12 @@ export default function NewAccountPage() {
               {clientsLoading ? (
                 <p className="text-sm text-slate-400 dark:text-slate-500">Loading clients…</p>
               ) : (
+                <div className="relative">
                 <select
                   name="ownerId"
                   value={form.ownerId}
                   onChange={handleChange}
-                  className={`input-field${errors.ownerId ? ' input-error' : ''}`}
+                  className={`input-field appearance-none pr-10${errors.ownerId ? ' input-error' : ''}`}
                 >
                   <option value="">Select a client…</option>
                   {[...clients]
@@ -157,6 +158,12 @@ export default function NewAccountPage() {
                       </option>
                     ))}
                 </select>
+                <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+                  <svg className="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+                </div>
               )}
             </Field>
             <div className="mt-3">
@@ -256,7 +263,7 @@ export default function NewAccountPage() {
             </button>
             <Link
               to="/admin/accounts"
-              className="px-5 py-2 text-xs tracking-widest uppercase border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:border-violet-500 dark:hover:border-violet-400 rounded-lg transition-colors"
+              className="inline-flex items-center justify-center px-5 py-2 text-xs tracking-widest uppercase border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:border-violet-500 dark:hover:border-violet-400 rounded-lg transition-colors"
             >
               Cancel
             </Link>

--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -1,40 +1,33 @@
-import { mockBankAccounts } from '../mocks/bankAccounts'
-import { BankAccount } from '../models/BankAccount'
-
-// In-memory store. Replace function bodies with real API calls when backend is ready.
-let _accounts = mockBankAccounts.map((a) => new BankAccount(a))
-
-let _nextId = mockBankAccounts.length + 1
-
-function generateAccountNumber() {
-  const padded = String(_nextId).padStart(10, '0')
-  const check  = String(_nextId % 100).padStart(2, '0')
-  return `105-${padded}-${check}`
-}
+import { apiClient } from './apiClient'
+import { bankAccountFromApi } from '../models/BankAccount'
 
 export const accountService = {
   async getAccounts() {
-    return [..._accounts]
+    const { data } = await apiClient.get('/api/accounts')
+    return data.map((a) => bankAccountFromApi({
+      id:               a.id,
+      accountNumber:    a.accountNumber,
+      accountName:      a.accountName,
+      ownerId:          a.ownerId,
+      ownerFirstName:   a.ownerFirstName,
+      ownerLastName:    a.ownerLastName,
+      type:             a.accountType,
+      currencyCode:     a.currencyCode,
+      availableBalance: a.availableBalance,
+    }))
   },
 
   async getAccountById(id) {
-    return _accounts.find((a) => a.id === id) ?? null
+    const { data } = await apiClient.get(`/api/accounts/${id}`)
+    return bankAccountFromApi({ id, ...data })
   },
 
-  async createAccount({ ownerId, ownerFirstName, ownerLastName, type, currencyType, currency, createdByEmployeeId }) {
-    const account = new BankAccount({
-      id: _nextId,
-      accountNumber: generateAccountNumber(),
-      ownerId,
-      ownerFirstName,
-      ownerLastName,
-      type,
-      currencyType,
-      currency,
-      createdByEmployeeId,
+  async createAccount({ ownerId, type, currency }) {
+    const { data } = await apiClient.post('/api/accounts/create', {
+      clientId:    ownerId,
+      accountType: type,
+      currencyCode: currency,
     })
-    _nextId++
-    _accounts = [..._accounts, account]
-    return account
+    return bankAccountFromApi(data)
   },
 }

--- a/src/services/clientAccountService.js
+++ b/src/services/clientAccountService.js
@@ -1,29 +1,18 @@
-/**
- * Client account service (mock)
- *
- * Returns the logged-in client's own accounts.
- * Replace function bodies with real API calls when backend is ready.
- */
-
-import { mockClientAccounts } from '../mocks/clientAccounts'
-
-// In-memory copy so name edits etc. can be persisted within a session
-let _accounts = [...mockClientAccounts]
+import { clientApiClient } from './clientApiClient'
+import { bankAccountFromApi } from '../models/BankAccount'
 
 export const clientAccountService = {
   async getMyAccounts() {
-    return [..._accounts]
+    const { data } = await clientApiClient.get('/api/accounts/my')
+    return data.map(bankAccountFromApi)
   },
 
   async getAccountById(id) {
-    return _accounts.find((a) => a.id === id) ?? null
+    const { data } = await clientApiClient.get(`/api/accounts/${id}`)
+    return bankAccountFromApi({ id, ...data })
   },
 
-  async applyTransfer({ fromAccountId, toAccountId, amount }) {
-    _accounts = _accounts.map((a) => {
-      if (a.id === fromAccountId) return { ...a, balance: a.balance - amount, availableBalance: a.availableBalance - amount }
-      if (a.id === toAccountId)   return { ...a, balance: a.balance + amount, availableBalance: a.availableBalance + amount }
-      return a
-    })
+  async renameAccount(id, newAccountName) {
+    await clientApiClient.put(`/api/accounts/${id}/name`, { newAccountName })
   },
 }


### PR DESCRIPTION
- Wire accountService.createAccount to POST /api/accounts/create
- Wire accountService.getAccounts to GET /api/accounts
- Wire clientAccountService to GET /api/accounts/my and GET /api/accounts/:id
- Add bankAccountFromApi mapper with lowercase type/status normalisation
- Show linked accounts on ClientDetailPage using AccountsContext
- Show red alert badge on clients without accounts on ClientsPage
- Fix select arrow on NewAccountPage with custom chevron