### PR TITLE
feat(#59/#60/#61): wire payment, recipient, and transfer services to …

### DIFF
--- a/src/context/ClientAccountsContext.jsx
+++ b/src/context/ClientAccountsContext.jsx
@@ -1,11 +1,13 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { clientAccountService } from '../services/clientAccountService'
+import { useClientAuth } from './ClientAuthContext'
 
 const ClientAccountsContext = createContext()
 
 export function ClientAccountsProvider({ children }) {
+  const { clientUser } = useClientAuth()
   const [accounts, setAccounts] = useState([])
-  const [loading, setLoading]   = useState(true)
+  const [loading, setLoading]   = useState(false)
   const [error, setError]       = useState(null)
 
   async function reload() {
@@ -32,7 +34,7 @@ export function ClientAccountsProvider({ children }) {
     )
   }
 
-  useEffect(() => { reload() }, [])
+  useEffect(() => { if (clientUser) reload() }, [clientUser])
 
   return (
     <ClientAccountsContext.Provider value={{ accounts, loading, error, reload, renameAccount }}>

--- a/src/context/ClientPaymentsContext.jsx
+++ b/src/context/ClientPaymentsContext.jsx
@@ -1,11 +1,13 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { paymentService } from '../services/paymentService'
+import { useClientAuth } from './ClientAuthContext'
 
 const ClientPaymentsContext = createContext()
 
 export function ClientPaymentsProvider({ children }) {
+  const { clientUser } = useClientAuth()
   const [payments, setPayments] = useState([])
-  const [loading, setLoading]   = useState(true)
+  const [loading, setLoading]   = useState(false)
   const [error, setError]       = useState(null)
 
   async function reload() {
@@ -21,7 +23,7 @@ export function ClientPaymentsProvider({ children }) {
     }
   }
 
-  useEffect(() => { reload() }, [])
+  useEffect(() => { if (clientUser) reload() }, [clientUser])
 
   return (
     <ClientPaymentsContext.Provider value={{ payments, loading, error, reload }}>

--- a/src/context/RecipientsContext.jsx
+++ b/src/context/RecipientsContext.jsx
@@ -1,11 +1,13 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { recipientService } from '../services/recipientService'
+import { useClientAuth } from './ClientAuthContext'
 
 const RecipientsContext = createContext()
 
 export function RecipientsProvider({ children }) {
+  const { clientUser } = useClientAuth()
   const [recipients, setRecipients] = useState([])
-  const [loading, setLoading]       = useState(true)
+  const [loading, setLoading]       = useState(false)
   const [error, setError]           = useState(null)
 
   async function reload() {
@@ -42,7 +44,7 @@ export function RecipientsProvider({ children }) {
     setRecipients(newList)
   }
 
-  useEffect(() => { reload() }, [])
+  useEffect(() => { if (clientUser) reload() }, [clientUser])
 
   return (
     <RecipientsContext.Provider value={{ recipients, loading, error, reload, addRecipient, updateRecipient, deleteRecipient, reorderRecipients }}>

--- a/src/models/Payment.js
+++ b/src/models/Payment.js
@@ -2,6 +2,7 @@ export class Payment {
   constructor({
     id,
     dateTime,
+    fromAccount,
     recipient,
     recipientAccount,
     amount,
@@ -13,6 +14,7 @@ export class Payment {
   }) {
     this.id               = id
     this.dateTime         = dateTime
+    this.fromAccount      = fromAccount
     this.recipient        = recipient
     this.recipientAccount = recipientAccount
     this.amount           = amount           ?? 0
@@ -33,6 +35,7 @@ export function paymentFromApi(data) {
   return new Payment({
     id:               data.id,
     dateTime:         data.dateTime       ?? data.date_time,
+    fromAccount:      data.fromAccount,
     recipient:        data.recipient,
     recipientAccount: data.recipientAccount ?? data.recipient_account,
     amount:           data.amount,

--- a/src/models/Recipient.js
+++ b/src/models/Recipient.js
@@ -18,3 +18,12 @@ export function recipientFromApi(data) {
 export function isValidAccountNumber(value) {
   return /^\d{3}-\d{10,13}-\d{2}$/.test(value.trim())
 }
+
+// Progressively formats digits as XXX-XXXXXXXXXXXXX-XX while typing or on paste.
+// Strips non-digits then inserts dashes at positions 3 and 16.
+export function formatAccountNumberInput(raw) {
+  const digits = raw.replace(/\D/g, '').slice(0, 18)
+  if (digits.length <= 3)  return digits
+  if (digits.length <= 16) return `${digits.slice(0, 3)}-${digits.slice(3)}`
+  return `${digits.slice(0, 3)}-${digits.slice(3, 16)}-${digits.slice(16)}`
+}

--- a/src/pages/client/ClientHomePage.jsx
+++ b/src/pages/client/ClientHomePage.jsx
@@ -155,6 +155,7 @@ export default function ClientHomePage() {
   const [eur, setEur] = useState('')
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
+  const myAccountNumbers = new Set(accounts.map((a) => a.accountNumber))
   const recentTransactions = payments.slice(0, 5)
 
   useEffect(() => {
@@ -375,12 +376,21 @@ export default function ClientHomePage() {
                       {recentTransactions.map((p) => (
                         <div key={p.id} onClick={() => navigate(`/client/payments/${p.id}`)} className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-white/60 dark:hover:bg-slate-800/40 transition-colors cursor-pointer">
                           <div className="min-w-0">
-                            <p className="text-sm text-slate-700 dark:text-slate-300 font-light truncate">{p.recipient}</p>
-                            <p className="text-xs text-slate-400 dark:text-slate-500">{p.dateTime.split(' ')[0]}</p>
+                            {(() => {
+                              const isOutgoing = myAccountNumbers.has(p.fromAccount)
+                              const otherParty = isOutgoing ? (p.recipient || p.recipientAccount) : p.fromAccount
+                              return <>
+                                <p className="text-sm text-slate-700 dark:text-slate-300 font-light truncate">{p.purpose || otherParty}</p>
+                                <p className="text-xs text-slate-400 dark:text-slate-500">{new Date(p.dateTime).toLocaleDateString('sr-RS')}</p>
+                              </>
+                            })()}
                           </div>
-                          <span className={`text-sm font-medium ml-4 shrink-0 ${p.amount > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-500 dark:text-slate-400'}`}>
-                            {p.amount > 0 ? '+' : ''}{fmt(p.amount)} {p.currency}
-                          </span>
+                          {(() => {
+                            const isOutgoing = myAccountNumbers.has(p.fromAccount)
+                            return <span className={`text-sm font-medium ml-4 shrink-0 ${isOutgoing ? 'text-red-500 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
+                              {isOutgoing ? '-' : '+'}{fmt(Math.abs(p.amount))} {p.currency}
+                            </span>
+                          })()}
                         </div>
                       ))}
                     </div>

--- a/src/pages/client/ClientNewPaymentPage.jsx
+++ b/src/pages/client/ClientNewPaymentPage.jsx
@@ -4,7 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { fmt } from '../../utils/formatting'
-import { isValidAccountNumber } from '../../models/Recipient'
+import { isValidAccountNumber, formatAccountNumberInput } from '../../models/Recipient'
 
 const EMPTY_FORM = {
   fromAccountId:    '',
@@ -45,7 +45,8 @@ export default function ClientNewPaymentPage() {
 
   function handleChange(e) {
     const { name, value } = e.target
-    setForm((prev) => ({ ...prev, [name]: value }))
+    const formatted = name === 'recipientAccount' ? formatAccountNumberInput(value) : value
+    setForm((prev) => ({ ...prev, [name]: formatted }))
     setErrors((prev) => ({ ...prev, [name]: undefined }))
   }
 

--- a/src/pages/client/ClientPaymentVerifyPage.jsx
+++ b/src/pages/client/ClientPaymentVerifyPage.jsx
@@ -3,6 +3,8 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useApiError } from '../../context/ApiErrorContext'
+import { paymentService } from '../../services/paymentService'
+import { useClientPayments } from '../../context/ClientPaymentsContext'
 
 function fmt(n, currency) {
   return n.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ` ${currency}`
@@ -22,7 +24,9 @@ export default function ClientPaymentVerifyPage() {
   const navigate = useNavigate()
   const { state } = useLocation()
   const { addSuccess } = useApiError()
+  const { reload: reloadPayments } = useClientPayments()
   const [confirmed, setConfirmed] = useState(false)
+  const [loading, setLoading]     = useState(false)
 
   // If landed here directly without payment data, go back
   if (!state) {
@@ -127,10 +131,29 @@ export default function ClientPaymentVerifyPage() {
           <p className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 mb-1">Mobile app</p>
           <p className="text-sm text-slate-500 dark:text-slate-400 font-light mb-5">Tap confirm below to simulate the in-app confirmation.</p>
           <button
-            onClick={() => { setConfirmed(true); addSuccess(`Payment to ${recipientName} has been submitted.`, 'Payment Confirmed') }}
+            disabled={loading}
+            onClick={async () => {
+              setLoading(true)
+              try {
+                await paymentService.createPayment({
+                  fromAccount:      fromAccount.accountNumber,
+                  recipientName,
+                  recipientAccount,
+                  amount,
+                  paymentCode,
+                  referenceNumber,
+                  purpose,
+                })
+                reloadPayments()
+                setConfirmed(true)
+                addSuccess(`Payment to ${recipientName} has been submitted.`, 'Payment Confirmed')
+              } finally {
+                setLoading(false)
+              }
+            }}
             className="btn-primary px-10"
           >
-            Confirm
+            {loading ? 'Processing…' : 'Confirm'}
           </button>
         </div>
 

--- a/src/pages/client/ClientPaymentsPage.jsx
+++ b/src/pages/client/ClientPaymentsPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useClientPayments } from '../../context/ClientPaymentsContext'
+import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { PAYMENT_STATUSES, PAYMENT_STATUS_STYLES } from '../../models/Payment'
 import { fmt } from '../../utils/formatting'
 import Spinner from '../../components/Spinner'
@@ -21,6 +22,8 @@ export default function ClientPaymentsPage() {
   useWindowTitle('Payments | AnkaBanka')
   const navigate = useNavigate()
   const { payments, loading } = useClientPayments()
+  const { accounts } = useClientAccounts()
+  const myAccountNumbers = useMemo(() => new Set(accounts.map((a) => a.accountNumber)), [accounts])
 
   const [filterDate,      setFilterDate]      = useState('')
   const [filterAmountMin, setFilterAmountMin] = useState('')
@@ -152,11 +155,18 @@ export default function ClientPaymentsPage() {
                     onClick={() => navigate(`/client/payments/${p.id}`)}
                     className={`cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors ${i !== filtered.length - 1 ? 'border-b border-slate-100 dark:border-slate-800' : ''}`}
                   >
-                    <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light whitespace-nowrap">{p.dateTime}</td>
-                    <td className="px-5 py-3.5 text-sm text-slate-900 dark:text-white font-light">{p.recipient}</td>
-                    <td className={`px-5 py-3.5 text-sm font-medium text-right whitespace-nowrap ${p.amount > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-700 dark:text-slate-300'}`}>
-                      {p.amount > 0 ? '+' : ''}{fmt(p.amount)}
-                    </td>
+                    {(() => {
+                      const isOutgoing = myAccountNumbers.has(p.fromAccount)
+                      const otherParty = isOutgoing ? (p.recipient || p.recipientAccount) : p.fromAccount
+                      const label = p.purpose || otherParty
+                      return <>
+                        <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light whitespace-nowrap">{new Date(p.dateTime).toLocaleString('sr-RS')}</td>
+                        <td className="px-5 py-3.5 text-sm text-slate-900 dark:text-white font-light">{label}</td>
+                        <td className={`px-5 py-3.5 text-sm font-medium text-right whitespace-nowrap ${isOutgoing ? 'text-red-500 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
+                          {isOutgoing ? '-' : '+'}{fmt(Math.abs(p.amount))}
+                        </td>
+                      </>
+                    })()}
                     <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light">{p.currency}</td>
                     <td className="px-5 py-3.5">
                       <StatusBadge status={p.status} />

--- a/src/pages/client/ClientRecipientsPage.jsx
+++ b/src/pages/client/ClientRecipientsPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useRecipients } from '../../context/RecipientsContext'
-import { isValidAccountNumber } from '../../models/Recipient'
+import { isValidAccountNumber, formatAccountNumberInput } from '../../models/Recipient'
 import Spinner from '../../components/Spinner'
 import { useApiError } from '../../context/ApiErrorContext'
 
@@ -15,7 +15,8 @@ function RecipientForm({ initial = { name: '', accountNumber: '' }, onSave, onCa
 
   function handleChange(e) {
     const { name, value } = e.target
-    setForm((prev) => ({ ...prev, [name]: value }))
+    const formatted = name === 'accountNumber' ? formatAccountNumberInput(value) : value
+    setForm((prev) => ({ ...prev, [name]: formatted }))
     setErrors((prev) => ({ ...prev, [name]: undefined }))
   }
 

--- a/src/pages/client/ClientTransfersPage.jsx
+++ b/src/pages/client/ClientTransfersPage.jsx
@@ -68,9 +68,9 @@ export default function ClientTransfersPage() {
     setLoading(true)
     try {
       await transferService.createTransfer({
-        fromAccountId: Number(form.fromAccountId),
-        toAccountId:   Number(form.toAccountId),
-        amount:        parseFloat(form.amount),
+        fromAccount: fromAccount.accountNumber,
+        toAccount:   toAccount.accountNumber,
+        amount:      parseFloat(form.amount),
       })
       await reloadAccounts()
       addSuccess(`${fmt(parseFloat(form.amount), fromAccount.currency)} transferred to ${toAccount.accountName}.`, 'Transfer Successful')

--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -1,18 +1,49 @@
-/**
- * Payment service (mock — client portal)
- *
- * Returns payments for the logged-in client.
- * Replace function bodies with real API calls when backend is ready.
- */
+import { clientApiClient } from './clientApiClient'
+import { paymentFromApi } from '../models/Payment'
 
-import { MOCK_PAYMENTS } from '../mocks/payments'
+function toPayment(p) {
+  return paymentFromApi({
+    id:               p.id,
+    dateTime:         p.timestamp,
+    fromAccount:      p.fromAccount,
+    recipient:        p.recipient,
+    recipientAccount: p.toAccount,
+    amount:           p.finalAmount,
+    fee:              p.fee,
+    currency:         p.currency,
+    status:           p.status?.toLowerCase(),
+    reference:        p.referenceNumber,
+    purpose:          p.purpose,
+  })
+}
 
 export const paymentService = {
-  async getPayments() {
-    return [...MOCK_PAYMENTS]
+  async getPayments(filters = {}) {
+    const params = {}
+    if (filters.dateFrom)  params.date_from  = filters.dateFrom
+    if (filters.dateTo)    params.date_to    = filters.dateTo
+    if (filters.amountMin) params.amount_min = filters.amountMin
+    if (filters.amountMax) params.amount_max = filters.amountMax
+    if (filters.status)    params.status     = filters.status.toUpperCase()
+    const { data } = await clientApiClient.get('/api/payments', { params })
+    return data.map(toPayment)
   },
 
   async getPaymentById(id) {
-    return MOCK_PAYMENTS.find((p) => p.id === id) ?? null
+    const { data } = await clientApiClient.get(`/api/payments/${id}`)
+    return toPayment(data)
+  },
+
+  async createPayment({ fromAccount, recipientName, recipientAccount, amount, paymentCode, referenceNumber, purpose }) {
+    const { data } = await clientApiClient.post('/api/payments/create', {
+      fromAccount:      fromAccount.replace(/-/g, ''),
+      recipientName,
+      recipientAccount: recipientAccount.replace(/-/g, ''),
+      amount,
+      paymentCode,
+      referenceNumber,
+      purpose,
+    })
+    return data
   },
 }

--- a/src/services/recipientService.js
+++ b/src/services/recipientService.js
@@ -1,37 +1,23 @@
-/**
- * Recipient service (mock)
- *
- * Replace function bodies with real API calls when backend is ready:
- *   GET    /api/recipients
- *   POST   /api/recipients
- *   PUT    /api/recipients/{id}
- *   DELETE /api/recipients/{id}
- */
-
-import { mockRecipients } from '../mocks/recipients'
-import { Recipient } from '../models/Recipient'
-
-let _recipients = [...mockRecipients]
-let _nextId = _recipients.length + 1
+import { clientApiClient } from './clientApiClient'
+import { recipientFromApi } from '../models/Recipient'
 
 export const recipientService = {
   async getRecipients() {
-    return [..._recipients]
+    const { data } = await clientApiClient.get('/api/recipients')
+    return data.map(recipientFromApi)
   },
 
   async createRecipient({ name, accountNumber }) {
-    const recipient = new Recipient({ id: _nextId++, name, accountNumber })
-    _recipients = [..._recipients, recipient]
-    return recipient
+    const { data } = await clientApiClient.post('/api/recipients', { name, accountNumber })
+    return recipientFromApi(data)
   },
 
   async updateRecipient(id, { name, accountNumber }) {
-    const recipient = new Recipient({ id, name, accountNumber })
-    _recipients = _recipients.map((r) => (r.id === id ? recipient : r))
-    return recipient
+    const { data } = await clientApiClient.put(`/api/recipients/${id}`, { name, accountNumber })
+    return recipientFromApi(data)
   },
 
   async deleteRecipient(id) {
-    _recipients = _recipients.filter((r) => r.id !== id)
+    await clientApiClient.delete(`/api/recipients/${id}`)
   },
 }

--- a/src/services/transferService.js
+++ b/src/services/transferService.js
@@ -1,21 +1,8 @@
-/**
- * Transfer service (mock)
- *
- * Replace the body of `createTransfer` with a real API call when backend is ready:
- *   POST /api/transfers
- */
-
-import { clientAccountService } from './clientAccountService'
+import { clientApiClient } from './clientApiClient'
 
 export const transferService = {
-  async createTransfer({ fromAccountId, toAccountId, amount }) {
-    await clientAccountService.applyTransfer({ fromAccountId, toAccountId, amount })
-    return {
-      id:            Math.floor(Math.random() * 100000),
-      fromAccountId,
-      toAccountId,
-      amount,
-      createdAt:     new Date().toISOString(),
-    }
+  async createTransfer({ fromAccount, toAccount, amount }) {
+    const { data } = await clientApiClient.post('/api/transfers', { fromAccount, toAccount, amount })
+    return data
   },
 }


### PR DESCRIPTION
…real API

- Replace mock paymentService with real GET/POST endpoints; map backend field names (timestamp, toAccount, finalAmount) and normalize status to lowercase; strip dashes from account numbers before sending
- Replace mock recipientService with real CRUD endpoints via clientApiClient
- Replace mock transferService with real POST /api/transfers
- Wire ClientPaymentVerifyPage to call createPayment on confirm and reload payments context immediately after
- Fix all three contexts (ClientAccounts, ClientPayments, Recipients) to only fetch when clientUser is set, preventing 401s on the landing page
- Add fromAccount to Payment model; show incoming payments (green +) vs outgoing (red -) based on whether fromAccount is in client's own accounts
- Show payment purpose in recipient column and recent transactions card
- Auto-format account number inputs with dashes as user types or pastes
- Format payment dates with toLocaleString instead of raw ISO string