### PR TITLE
feat(#71/#70/#67): employee account detail + company data + limits

### DIFF
--- a/src/models/BankAccount.js
+++ b/src/models/BankAccount.js
@@ -27,6 +27,7 @@ export class BankAccount {
     monthlyLimit,
     dailySpending,
     monthlySpending,
+    company,
   }) {
     this.id                  = id
     this.accountNumber       = accountNumber
@@ -58,6 +59,8 @@ export class BankAccount {
     this.monthlyLimit        = monthlyLimit        ?? 1000000  // max transaction amount per month
     this.dailySpending       = dailySpending       ?? 0    // total spent today
     this.monthlySpending     = monthlySpending     ?? 0    // total spent this month
+    // Business accounts only: { name, pib, registrationNumber, address, activityCode }
+    this.company             = company             ?? null
   }
 
   get ownerFullName() {
@@ -112,5 +115,6 @@ export function bankAccountFromApi(data) {
     monthlyLimit:     data.monthlyLimit   ?? 1000000,
     dailySpending:    data.dailySpent     ?? 0,
     monthlySpending:  data.monthlySpent   ?? 0,
+    company:          data.company        ?? null,
   })
 }

--- a/src/pages/employee/AccountDetailPage.jsx
+++ b/src/pages/employee/AccountDetailPage.jsx
@@ -1,95 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
-import { useAccounts } from '../../context/AccountsContext'
-
-export default function AccountDetailPage() {
-  const { id } = useParams()
-  const { accounts, loading, reload } = useAccounts()
-
-  useEffect(() => {
-    if (accounts.length === 0 && !loading) reload()
-  }, [])
-
-  const account = accounts.find((a) => a.id === Number(id))
-
-  useWindowTitle(account ? `${account.accountNumber} | AnkaBanka` : 'Account | AnkaBanka')
-
-  if (!account) {
-    return (
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center text-center px-6">
-        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Not Found</p>
-        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-6">Account not found</h1>
-        <Link to="/admin/accounts" className="btn-primary">Back to Accounts</Link>
-      </div>
-    )
-  }
-
-  return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
-      <div className="max-w-2xl mx-auto">
-
-        {/* Back */}
-        <Link
-          to="/admin/accounts"
-          className="inline-flex items-center gap-2 text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 transition-colors mb-10"
-        >
-          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-          </svg>
-          All Accounts
-        </Link>
-
-        {/* Header */}
-        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Account</p>
-        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3 font-mono tracking-wide">
-          {account.accountNumber}
-        </h1>
-        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
-
-        {/* Details card */}
-        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm mb-6">
-          <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 pb-3">Account Info</p>
-
-          <Row label="Account Number" value={account.accountNumber} mono />
-          <Row label="Owner" value={account.ownerFullName} />
-          <Row
-            label="Type"
-            value={
-              <span className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium tracking-wide rounded-full ${
-                account.type === 'personal'
-                  ? 'bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400'
-                  : 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-              }`}>
-                {account.type === 'personal' ? 'Personal' : 'Business'}
-              </span>
-            }
-          />
-          <Row
-            label="Currency Type"
-            value={
-              <span className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium tracking-wide rounded-full ${
-                account.currencyType === 'current'
-                  ? 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
-                  : 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-              }`}>
-                {account.currencyType === 'current' ? 'Current' : 'Foreign Currency'}
-              </span>
-            }
-          />
-          {account.currency && <Row label="Currency" value={account.currency} />}
-        </div>
-
-        {/* Cards section — placeholder until issue #41 */}
-        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
-          <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 pb-3">Cards</p>
-          <p className="text-sm text-slate-400 dark:text-slate-500">No cards linked to this account.</p>
-        </div>
-
-      </div>
-    </div>
-  )
-}
+import { accountService } from '../../services/accountService'
+import { BankAccount } from '../../models/BankAccount'
+import { fmt } from '../../utils/formatting'
+import Spinner from '../../components/Spinner'
+import { useApiError } from '../../context/ApiErrorContext'
 
 function Row({ label, value, mono = false }) {
   return (
@@ -102,6 +18,270 @@ function Row({ label, value, mono = false }) {
       ) : (
         value
       )}
+    </div>
+  )
+}
+
+function Card({ title, children, action }) {
+  return (
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
+      <div className="flex items-center justify-between pb-3">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400">{title}</p>
+        {action}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default function AccountDetailPage() {
+  const { id } = useParams()
+  const { addSuccess } = useApiError()
+  const [account, setAccount]           = useState(null)
+  const [loading, setLoading]           = useState(true)
+  const [editingLimits, setEditingLimits] = useState(false)
+  const [limitForm, setLimitForm]       = useState({ dailyLimit: '', monthlyLimit: '' })
+  const [limitErrors, setLimitErrors]   = useState({})
+  const [limitsLoading, setLimitsLoading] = useState(false)
+
+  useWindowTitle(account ? `${account.accountNumber} | AnkaBanka` : 'Account | AnkaBanka')
+
+  useEffect(() => {
+    accountService.getAccountById(id)
+      .then((data) => {
+        setAccount(data)
+        setLimitForm({ dailyLimit: String(data.dailyLimit), monthlyLimit: String(data.monthlyLimit) })
+      })
+      .catch(() => setAccount(null))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (!account) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center text-center px-6">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Not Found</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-6">Account not found</h1>
+        <Link to="/admin/accounts" className="btn-primary">Back to Accounts</Link>
+      </div>
+    )
+  }
+
+  const reserved = account.balance - account.availableBalance
+
+  function validateLimits() {
+    const errs = {}
+    const daily   = parseFloat(limitForm.dailyLimit)
+    const monthly = parseFloat(limitForm.monthlyLimit)
+    if (!limitForm.dailyLimit   || isNaN(daily)   || daily   <= 0) errs.dailyLimit   = 'Must be a positive number.'
+    if (!limitForm.monthlyLimit || isNaN(monthly) || monthly <= 0) errs.monthlyLimit = 'Must be a positive number.'
+    if (!errs.dailyLimit && !errs.monthlyLimit && daily > monthly)
+      errs.dailyLimit = 'Daily limit cannot exceed the monthly limit.'
+    return errs
+  }
+
+  async function saveLimits() {
+    const errs = validateLimits()
+    if (Object.keys(errs).length) { setLimitErrors(errs); return }
+    setLimitsLoading(true)
+    try {
+      await accountService.updateAccountLimits(account.id, {
+        dailyLimit:   parseFloat(limitForm.dailyLimit),
+        monthlyLimit: parseFloat(limitForm.monthlyLimit),
+      })
+      setAccount(new BankAccount({
+        ...account,
+        dailyLimit:   parseFloat(limitForm.dailyLimit),
+        monthlyLimit: parseFloat(limitForm.monthlyLimit),
+      }))
+      setEditingLimits(false)
+      setLimitErrors({})
+      addSuccess('Account limits updated successfully.', 'Saved')
+    } finally {
+      setLimitsLoading(false)
+    }
+  }
+
+  function startEditingLimits() {
+    setLimitForm({ dailyLimit: String(account.dailyLimit), monthlyLimit: String(account.monthlyLimit) })
+    setLimitErrors({})
+    setEditingLimits(true)
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-2xl mx-auto space-y-6">
+
+        {/* Back */}
+        <Link
+          to="/admin/accounts"
+          className="inline-flex items-center gap-2 text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 transition-colors"
+        >
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          All Accounts
+        </Link>
+
+        {/* Header */}
+        <div>
+          <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Account</p>
+          <div className="flex items-start justify-between gap-4">
+            <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white font-mono tracking-wide">
+              {account.accountNumber}
+            </h1>
+            <span className={`mt-2 shrink-0 text-xs px-3 py-1 rounded-full font-light ${
+              account.isActive
+                ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400'
+                : 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400'
+            }`}>
+              {account.status}
+            </span>
+          </div>
+          <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mt-3" />
+        </div>
+
+        {/* Account Info */}
+        <Card title="Account Info">
+          <Row label="Account Number" value={account.accountNumber} mono />
+          <Row label="Account Name"   value={account.accountName ?? '—'} />
+          <Row label="Owner"          value={account.ownerFullName} />
+          <Row label="Type" value={
+            <span className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium tracking-wide rounded-full ${
+              account.type === 'personal'
+                ? 'bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400'
+                : 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+            }`}>
+              {account.type === 'personal' ? 'Personal' : 'Business'}
+            </span>
+          } />
+          <Row label="Subtype"  value={account.subtype ?? '—'} />
+          <Row label="Currency" value={account.currency} />
+          <Row label="Currency Type" value={
+            <span className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium tracking-wide rounded-full ${
+              account.currencyType === 'current'
+                ? 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+                : 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+            }`}>
+              {account.currencyType === 'current' ? 'Current' : 'Foreign Currency'}
+            </span>
+          } />
+          {account.maintenanceFee > 0 && (
+            <Row label="Maintenance Fee" value={fmt(account.maintenanceFee, account.currency) + ' / month'} />
+          )}
+          {account.createdAt && <Row label="Created"  value={new Date(account.createdAt).toLocaleDateString('sr-RS')} />}
+          {account.expiresAt && <Row label="Expires"  value={new Date(account.expiresAt).toLocaleDateString('sr-RS')} />}
+        </Card>
+
+        {/* Balance */}
+        <Card title="Balance">
+          <Row label="Available Balance" value={fmt(account.availableBalance, account.currency)} />
+          <Row label="Total Balance"     value={fmt(account.balance, account.currency)} />
+          <Row label="Reserved Funds"    value={fmt(reserved, account.currency)} />
+        </Card>
+
+        {/* Limits & Spending */}
+        <Card
+          title="Limits & Spending"
+          action={
+            !editingLimits && (
+              <button
+                onClick={startEditingLimits}
+                className="text-xs tracking-widest uppercase text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 transition-colors"
+              >
+                Edit
+              </button>
+            )
+          }
+        >
+          {editingLimits ? (
+            <div className="space-y-4 pt-1">
+              <LimitField
+                label="Daily Limit *"
+                currency={account.currency}
+                value={limitForm.dailyLimit}
+                error={limitErrors.dailyLimit}
+                onChange={(v) => { setLimitForm((p) => ({ ...p, dailyLimit: v })); setLimitErrors((p) => ({ ...p, dailyLimit: undefined })) }}
+              />
+              <LimitField
+                label="Monthly Limit *"
+                currency={account.currency}
+                value={limitForm.monthlyLimit}
+                error={limitErrors.monthlyLimit}
+                onChange={(v) => { setLimitForm((p) => ({ ...p, monthlyLimit: v })); setLimitErrors((p) => ({ ...p, monthlyLimit: undefined })) }}
+              />
+              <div className="flex gap-3 pt-2">
+                <button
+                  onClick={saveLimits}
+                  disabled={limitsLoading}
+                  className="btn-primary"
+                >
+                  {limitsLoading ? 'Saving…' : 'Save'}
+                </button>
+                <button
+                  onClick={() => { setEditingLimits(false); setLimitErrors({}) }}
+                  className="px-5 py-2 text-xs tracking-widest uppercase border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:border-violet-500 dark:hover:border-violet-400 rounded-lg transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <Row label="Daily Limit"      value={fmt(account.dailyLimit, account.currency)} />
+              <Row label="Monthly Limit"    value={fmt(account.monthlyLimit, account.currency)} />
+              <Row label="Spent Today"      value={fmt(account.dailySpending, account.currency)} />
+              <Row label="Spent This Month" value={fmt(account.monthlySpending, account.currency)} />
+            </>
+          )}
+        </Card>
+
+        {/* Company Info — business accounts only */}
+        {account.type === 'business' && account.company && (
+          <Card title="Company Info">
+            <Row label="Company Name"        value={account.company.name ?? '—'} />
+            <Row label="Registration Number" value={account.company.registrationNumber ?? '—'} />
+            <Row label="PIB"                 value={account.company.pib ?? '—'} />
+            <Row label="Activity Code"       value={account.company.activityCode ?? '—'} />
+            <Row label="Address"             value={account.company.address ?? '—'} />
+          </Card>
+        )}
+
+        {/* Cards */}
+        <Card title="Cards">
+          <p className="text-sm text-slate-400 dark:text-slate-500">No cards linked to this account.</p>
+        </Card>
+
+      </div>
+    </div>
+  )
+}
+
+function LimitField({ label, currency, value, error, onChange }) {
+  return (
+    <div>
+      <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-1">{label}</label>
+      <div className="relative">
+        <input
+          type="number"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          min="1"
+          step="1"
+          className={`input-field pr-16 ${error ? 'input-error' : ''}`}
+        />
+        <span className="absolute right-4 top-1/2 -translate-y-1/2 text-xs text-slate-400 dark:text-slate-500 pointer-events-none">
+          {currency}
+        </span>
+      </div>
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
     </div>
   )
 }

--- a/src/pages/employee/NewAccountPage.jsx
+++ b/src/pages/employee/NewAccountPage.jsx
@@ -8,6 +8,11 @@ import { PERSONAL_SUBTYPES, BUSINESS_SUBTYPES } from '../../models/BankAccount'
 
 const FOREIGN_CURRENCIES = ['EUR', 'USD', 'GBP', 'CHF', 'JPY', 'CAD', 'AUD']
 
+const ACTIVITY_CODES = [
+  '01.1', '10.1', '41.2', '45.1', '46.1', '47.1', '56.1',
+  '62.01', '62.02', '64.19', '69.1', '70.2', '85.3', '86.1', '96.0',
+]
+
 const EMPTY_FORM = {
   ownerId:      '',
   type:         'personal',
@@ -17,10 +22,39 @@ const EMPTY_FORM = {
   currency:     'RSD',
 }
 
+const EMPTY_COMPANY = {
+  name:               '',
+  registrationNumber: '',
+  pib:                '',
+  activityCode:       '',
+  address:            '',
+}
+
+const EMPTY_LIMITS = {
+  dailyLimit:   '',
+  monthlyLimit: '',
+}
+
 function defaultName(type, subtype) {
   const list = type === 'personal' ? PERSONAL_SUBTYPES : BUSINESS_SUBTYPES
   const found = list.find((s) => s.value === subtype)
   return found ? `${found.label} Account` : ''
+}
+
+function defaultLimits(type, subtype) {
+  if (type === 'business') {
+    if (subtype === 'foundation') return { dailyLimit: '100000', monthlyLimit: '1000000' }
+    return { dailyLimit: '500000', monthlyLimit: '5000000' }
+  }
+  switch (subtype) {
+    case 'standard':   return { dailyLimit: '250000', monthlyLimit: '1000000' }
+    case 'savings':    return { dailyLimit: '50000',  monthlyLimit: '200000'  }
+    case 'pensioner':  return { dailyLimit: '50000',  monthlyLimit: '200000'  }
+    case 'youth':      return { dailyLimit: '25000',  monthlyLimit: '100000'  }
+    case 'student':    return { dailyLimit: '25000',  monthlyLimit: '100000'  }
+    case 'unemployed': return { dailyLimit: '10000',  monthlyLimit: '50000'   }
+    default:           return { dailyLimit: '250000', monthlyLimit: '1000000' }
+  }
 }
 
 export default function NewAccountPage() {
@@ -31,8 +65,10 @@ export default function NewAccountPage() {
   const { clients, loading: clientsLoading, reload: reloadClients } = useClients()
   const { user } = useAuth()
 
-  const [form, setForm]     = useState({ ...EMPTY_FORM, ownerId: searchParams.get('clientId') ?? '' })
-  const [errors, setErrors] = useState({})
+  const [form, setForm]       = useState({ ...EMPTY_FORM, ownerId: searchParams.get('clientId') ?? '' })
+  const [company, setCompany] = useState(EMPTY_COMPANY)
+  const [limits, setLimits]   = useState(EMPTY_LIMITS)
+  const [errors, setErrors]   = useState({})
   const [success, setSuccess] = useState(null)
 
   useEffect(() => {
@@ -52,6 +88,8 @@ export default function NewAccountPage() {
         currencyType: 'current',
         currency:     'RSD',
       }))
+      setCompany(EMPTY_COMPANY)
+      setLimits(EMPTY_LIMITS)
       return
     }
 
@@ -61,6 +99,7 @@ export default function NewAccountPage() {
         subtype:     value,
         accountName: defaultName(prev.type, value),
       }))
+      setLimits(defaultLimits(form.type, value))
       return
     }
 
@@ -76,12 +115,37 @@ export default function NewAccountPage() {
     setForm((prev) => ({ ...prev, [name]: value }))
   }
 
+  function handleCompanyChange(e) {
+    const { name, value } = e.target
+    setErrors((prev) => ({ ...prev, [`company_${name}`]: false }))
+    setCompany((prev) => ({ ...prev, [name]: value }))
+  }
+
+  function handleLimitsChange(e) {
+    const { name, value } = e.target
+    setErrors((prev) => ({ ...prev, [name]: false }))
+    setLimits((prev) => ({ ...prev, [name]: value }))
+  }
+
   function validate() {
     const errs = {}
-    if (!form.ownerId)  errs.ownerId  = true
-    if (!form.subtype)  errs.subtype  = true
+    if (!form.ownerId)            errs.ownerId     = true
+    if (!form.subtype)            errs.subtype     = true
     if (!form.accountName.trim()) errs.accountName = true
     if (form.type === 'personal' && form.currencyType === 'foreign' && !form.currency) errs.currency = true
+
+    if (form.type === 'business') {
+      if (!company.name.trim())               errs.company_name               = true
+      if (!company.registrationNumber.trim()) errs.company_registrationNumber = true
+      if (!company.pib.trim())               errs.company_pib               = true
+    }
+
+    const daily   = parseFloat(limits.dailyLimit)
+    const monthly = parseFloat(limits.monthlyLimit)
+    if (!limits.dailyLimit   || isNaN(daily)   || daily   <= 0) errs.dailyLimit   = true
+    if (!limits.monthlyLimit || isNaN(monthly) || monthly <= 0) errs.monthlyLimit = true
+    if (!errs.dailyLimit && !errs.monthlyLimit && daily > monthly) errs.dailyLimit = true
+
     return errs
   }
 
@@ -103,6 +167,17 @@ export default function NewAccountPage() {
         currencyType:        form.currencyType,
         currency:            form.currency,
         createdByEmployeeId: user?.id ?? null,
+        dailyLimit:          parseFloat(limits.dailyLimit),
+        monthlyLimit:        parseFloat(limits.monthlyLimit),
+        ...(form.type === 'business' && {
+          companyData: {
+            name:               company.name.trim(),
+            registrationNumber: company.registrationNumber.trim(),
+            pib:                company.pib.trim(),
+            activityCode:       company.activityCode || null,
+            address:            company.address.trim() || null,
+          },
+        }),
       })
       setSuccess({ accountNumber: created.accountNumber, ownerEmail: owner.email, ownerName: owner.fullName })
     } catch {
@@ -129,7 +204,7 @@ export default function NewAccountPage() {
             </p>
             <div className="flex gap-3 justify-center">
               <button
-                onClick={() => { setForm(EMPTY_FORM); setSuccess(null) }}
+                onClick={() => { setForm(EMPTY_FORM); setCompany(EMPTY_COMPANY); setLimits(EMPTY_LIMITS); setSuccess(null) }}
                 className="px-5 py-2 text-xs tracking-widest uppercase border border-violet-600 dark:border-violet-400 text-violet-600 dark:text-violet-400 hover:bg-violet-600 dark:hover:bg-violet-500 hover:text-white rounded-lg transition-colors"
               >
                 New Account
@@ -215,7 +290,7 @@ export default function NewAccountPage() {
             </div>
           </div>
 
-          {/* Account details */}
+          {/* Account Details */}
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
             <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-6">Account Details</p>
 
@@ -265,7 +340,7 @@ export default function NewAccountPage() {
                 </div>
               </Field>
 
-              {/* Account name — auto-filled from subtype, editable */}
+              {/* Account name */}
               <Field label="Account Name *" error={errors.accountName}>
                 <input
                   type="text"
@@ -299,15 +374,9 @@ export default function NewAccountPage() {
                 </div>
               </Field>
 
-              {/* Currency display / selection */}
               {form.currencyType === 'current' && (
                 <Field label="Currency">
-                  <input
-                    type="text"
-                    value="RSD"
-                    disabled
-                    className="input-field opacity-50 cursor-not-allowed"
-                  />
+                  <input type="text" value="RSD" disabled className="input-field opacity-50 cursor-not-allowed" />
                 </Field>
               )}
 
@@ -327,6 +396,128 @@ export default function NewAccountPage() {
                 </Field>
               )}
 
+            </div>
+          </div>
+
+          {/* Company Details — business accounts only */}
+          {form.type === 'business' && (
+            <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
+              <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-6">Company Details</p>
+              <div className="space-y-5">
+
+                <Field label="Company Name *" error={errors.company_name}>
+                  <input
+                    type="text"
+                    name="name"
+                    value={company.name}
+                    onChange={handleCompanyChange}
+                    placeholder="e.g. Acme d.o.o."
+                    className={`input-field${errors.company_name ? ' input-error' : ''}`}
+                  />
+                </Field>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <Field label="Registration Number *" error={errors.company_registrationNumber}>
+                    <input
+                      type="text"
+                      name="registrationNumber"
+                      value={company.registrationNumber}
+                      onChange={handleCompanyChange}
+                      placeholder="e.g. 12345678"
+                      className={`input-field font-mono${errors.company_registrationNumber ? ' input-error' : ''}`}
+                    />
+                  </Field>
+
+                  <Field label="PIB *" error={errors.company_pib}>
+                    <input
+                      type="text"
+                      name="pib"
+                      value={company.pib}
+                      onChange={handleCompanyChange}
+                      placeholder="e.g. 123456789"
+                      className={`input-field font-mono${errors.company_pib ? ' input-error' : ''}`}
+                    />
+                  </Field>
+                </div>
+
+                <Field label="Activity Code">
+                  <div className="relative">
+                    <select
+                      name="activityCode"
+                      value={company.activityCode}
+                      onChange={handleCompanyChange}
+                      className="input-field appearance-none pr-10"
+                    >
+                      <option value="">Select activity code…</option>
+                      {ACTIVITY_CODES.map((code) => (
+                        <option key={code} value={code}>{code}</option>
+                      ))}
+                    </select>
+                    <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+                      <svg className="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                      </svg>
+                    </div>
+                  </div>
+                </Field>
+
+                <Field label="Address">
+                  <input
+                    type="text"
+                    name="address"
+                    value={company.address}
+                    onChange={handleCompanyChange}
+                    placeholder="Street, City"
+                    className="input-field"
+                  />
+                </Field>
+
+              </div>
+            </div>
+          )}
+
+          {/* Limits */}
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-8 shadow-sm">
+            <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-1">Transaction Limits</p>
+            <p className="text-xs text-slate-400 dark:text-slate-500 mb-6">
+              Auto-filled based on account subtype. You can override these values.
+            </p>
+            <div className="grid grid-cols-2 gap-4">
+              <Field label="Daily Limit *" error={errors.dailyLimit}>
+                <div className="relative">
+                  <input
+                    type="number"
+                    name="dailyLimit"
+                    value={limits.dailyLimit}
+                    onChange={handleLimitsChange}
+                    placeholder="250000"
+                    min="1"
+                    step="1"
+                    className={`input-field pr-14${errors.dailyLimit ? ' input-error' : ''}`}
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 dark:text-slate-500 pointer-events-none">
+                    RSD
+                  </span>
+                </div>
+              </Field>
+
+              <Field label="Monthly Limit *" error={errors.monthlyLimit}>
+                <div className="relative">
+                  <input
+                    type="number"
+                    name="monthlyLimit"
+                    value={limits.monthlyLimit}
+                    onChange={handleLimitsChange}
+                    placeholder="1000000"
+                    min="1"
+                    step="1"
+                    className={`input-field pr-14${errors.monthlyLimit ? ' input-error' : ''}`}
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 dark:text-slate-500 pointer-events-none">
+                    RSD
+                  </span>
+                </div>
+              </Field>
             </div>
           </div>
 

--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -22,7 +22,7 @@ export const accountService = {
     return bankAccountFromApi({ id, ...data })
   },
 
-  async createAccount({ ownerId, ownerFirstName, ownerLastName, type, subtype, accountName, currencyType, currency }) {
+  async createAccount({ ownerId, ownerFirstName, ownerLastName, type, subtype, accountName, currencyType, currency, companyData, dailyLimit, monthlyLimit }) {
     let accountType
     if (currencyType === 'foreign') {
       accountType = 'FOREIGN_CURRENCY'
@@ -38,7 +38,14 @@ export const accountService = {
       accountType,
       accountName,
       currencyCode: currency,
+      ...(companyData  && { companyData }),
+      ...(dailyLimit   && { dailyLimit }),
+      ...(monthlyLimit && { monthlyLimit }),
     })
     return bankAccountFromApi({ ownerFirstName, ownerLastName, ...data })
+  },
+
+  async updateAccountLimits(id, { dailyLimit, monthlyLimit }) {
+    await apiClient.put(`/api/accounts/${id}/limits`, { dailyLimit, monthlyLimit })
   },
 }


### PR DESCRIPTION
- AccountDetailPage: fetch full account via GET /api/accounts/:id, display balance, status, subtype, maintenance fee, dates, and editable limits & spending; show company info for business accounts
- NewAccountPage: add Company Details section (name, reg number, PIB, activity code, address) shown when type=business; add Transaction Limits section with subtype-aware defaults (auto-filled, overridable)
- accountService: pass companyData and limits in createAccount payload; add updateAccountLimits (PUT /api/accounts/:id/limits)
- BankAccount model: add company field and map it in bankAccountFromApi