### PR TITLE
feat: employee loan applications and all loans pages (#93, #94)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,8 @@ import ClientLoanApplyPage from './pages/client/ClientLoanApplyPage'
 import ClientRecipientsPage from './pages/client/ClientRecipientsPage'
 import SetPasswordPage from './pages/employee/SetPasswordPage'
 import ResetPasswordPage from './pages/employee/ResetPasswordPage'
+import EmployeeLoanApplicationsPage from './pages/employee/EmployeeLoanApplicationsPage'
+import EmployeeLoansPage from './pages/employee/EmployeeLoansPage'
 import NotFoundPage from './pages/NotFoundPage'
 
 function App() {
@@ -72,6 +74,8 @@ function App() {
               <Route path="/admin/accounts" element={<ClientAccountsPage />} />
               <Route path="/admin/accounts/new" element={<NewAccountPage />} />
               <Route path="/admin/accounts/:id" element={<AccountDetailPage />} />
+              <Route path="/admin/loans/applications" element={<EmployeeLoanApplicationsPage />} />
+              <Route path="/admin/loans" element={<EmployeeLoansPage />} />
             </Route>
           </Route>
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -48,6 +48,12 @@ function Navbar() {
             {user?.permissions?.canViewClients && (
               <NavLink to="/admin/accounts" className={linkClass}>Accounts</NavLink>
             )}
+            {user && (
+              <NavLink to="/admin/loans/applications" className={linkClass}>Loan Applications</NavLink>
+            )}
+            {user && (
+              <NavLink to="/admin/loans" className={linkClass}>Loans</NavLink>
+            )}
           </div>
 
           {/* Desktop CTA */}
@@ -112,6 +118,12 @@ function Navbar() {
             )}
             {user?.permissions?.canViewClients && (
               <NavLink to="/admin/accounts" className={linkClass} onClick={() => setMenuOpen(false)}>Accounts</NavLink>
+            )}
+            {user && (
+              <NavLink to="/admin/loans/applications" className={linkClass} onClick={() => setMenuOpen(false)}>Loan Applications</NavLink>
+            )}
+            {user && (
+              <NavLink to="/admin/loans" className={linkClass} onClick={() => setMenuOpen(false)}>Loans</NavLink>
             )}
             <div className="flex items-center gap-4">
               <button

--- a/src/pages/employee/EmployeeLoanApplicationsPage.jsx
+++ b/src/pages/employee/EmployeeLoanApplicationsPage.jsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { employeeLoanService } from '../../services/loanService'
+import { fmt } from '../../utils/formatting'
+
+const LOAN_TYPES = ['CASH', 'HOUSING', 'AUTO', 'REFINANCING', 'STUDENT']
+
+const LOAN_TYPE_LABELS = {
+  CASH: 'Cash', HOUSING: 'Housing', AUTO: 'Auto', REFINANCING: 'Refinancing', STUDENT: 'Student',
+}
+
+function InfoRow({ label, value }) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-2 border-b border-slate-100 dark:border-slate-800 last:border-0">
+      <span className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 shrink-0">{label}</span>
+      <span className="text-sm text-slate-800 dark:text-slate-200 text-right">{value ?? '—'}</span>
+    </div>
+  )
+}
+
+function ApplicationCard({ app, onApprove, onReject }) {
+  const [confirming, setConfirming] = useState(null) // 'approve' | 'reject' | null
+  const [busy, setBusy] = useState(false)
+
+  async function handle(action) {
+    setBusy(true)
+    try {
+      await (action === 'approve' ? onApprove(app.id) : onReject(app.id))
+    } finally {
+      setBusy(false)
+      setConfirming(null)
+    }
+  }
+
+  return (
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-1">
+            {LOAN_TYPE_LABELS[app.loanType] ?? app.loanType} Loan
+          </p>
+          <p className="font-mono text-slate-900 dark:text-white font-medium">#{app.loanNumber}</p>
+        </div>
+        <span className="text-lg font-serif font-light text-slate-900 dark:text-white">
+          {fmt(app.amount, app.currency)}
+        </span>
+      </div>
+
+      <div className="space-y-0 mb-5">
+        <InfoRow label="Account"          value={app.accountNumber} />
+        <InfoRow label="Interest Rate"    value={app.interestRateType} />
+        <InfoRow label="Repayment Period" value={app.repaymentPeriod ? `${app.repaymentPeriod} months` : null} />
+        <InfoRow label="Purpose"          value={app.purpose} />
+        <InfoRow label="Monthly Salary"   value={app.monthlySalary ? fmt(app.monthlySalary, app.currency) : null} />
+        <InfoRow label="Employment"       value={app.employmentStatus} />
+        <InfoRow label="Empl. Period"     value={app.employmentPeriod ? `${app.employmentPeriod} months` : null} />
+        <InfoRow label="Contact Phone"    value={app.contactPhone} />
+        <InfoRow label="Agreement Date"   value={app.agreedDate} />
+      </div>
+
+      {confirming ? (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-slate-600 dark:text-slate-300">
+            {confirming === 'approve' ? 'Approve this application?' : 'Reject this application?'}
+          </span>
+          <button
+            onClick={() => handle(confirming)}
+            disabled={busy}
+            className={`px-4 py-1.5 text-xs tracking-widest uppercase rounded-lg text-white transition-colors ${
+              confirming === 'approve'
+                ? 'bg-emerald-600 hover:bg-emerald-700'
+                : 'bg-red-500 hover:bg-red-600'
+            }`}
+          >
+            {busy ? '…' : 'Confirm'}
+          </button>
+          <button
+            onClick={() => setConfirming(null)}
+            disabled={busy}
+            className="text-xs tracking-widest uppercase text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <div className="flex gap-3">
+          <button
+            onClick={() => setConfirming('approve')}
+            className="px-4 py-1.5 text-xs tracking-widest uppercase rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white transition-colors"
+          >
+            Approve
+          </button>
+          <button
+            onClick={() => setConfirming('reject')}
+            className="px-4 py-1.5 text-xs tracking-widest uppercase rounded-lg border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+          >
+            Reject
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function EmployeeLoanApplicationsPage() {
+  useWindowTitle('Loan Applications | AnkaBanka')
+
+  const [applications, setApplications] = useState([])
+  const [loading, setLoading]           = useState(true)
+  const [filters, setFilters]           = useState({ loanType: '', accountNumber: '' })
+  const [toast, setToast]               = useState(null)
+
+  function showToast(msg, type = 'success') {
+    setToast({ msg, type })
+    setTimeout(() => setToast(null), 3000)
+  }
+
+  function load() {
+    setLoading(true)
+    employeeLoanService.getLoanApplications()
+      .then(setApplications)
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function handleApprove(id) {
+    await employeeLoanService.approveLoan(id)
+    setApplications((prev) => prev.filter((a) => a.id !== id))
+    showToast('Loan approved.')
+  }
+
+  async function handleReject(id) {
+    await employeeLoanService.rejectLoan(id)
+    setApplications((prev) => prev.filter((a) => a.id !== id))
+    showToast('Loan rejected.')
+  }
+
+  const displayed = applications.filter((a) => {
+    const typeMatch = !filters.loanType || a.loanType === filters.loanType
+    const accMatch  = !filters.accountNumber.trim() ||
+      a.accountNumber?.toLowerCase().includes(filters.accountNumber.trim().toLowerCase())
+    return typeMatch && accMatch
+  })
+
+  const hasFilters = filters.loanType || filters.accountNumber
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-4xl mx-auto">
+
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-1">Loan Applications</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-10" />
+
+        {/* Filters */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 mb-6 shadow-sm">
+          <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-4">Filter</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <select
+              value={filters.loanType}
+              onChange={(e) => setFilters((p) => ({ ...p, loanType: e.target.value }))}
+              className="input-field"
+            >
+              <option value="">All loan types</option>
+              {LOAN_TYPES.map((t) => <option key={t} value={t}>{LOAN_TYPE_LABELS[t]}</option>)}
+            </select>
+            <input
+              type="text"
+              value={filters.accountNumber}
+              onChange={(e) => setFilters((p) => ({ ...p, accountNumber: e.target.value }))}
+              placeholder="Account number"
+              className="input-field"
+            />
+          </div>
+          {hasFilters && (
+            <button
+              onClick={() => setFilters({ loanType: '', accountNumber: '' })}
+              className="mt-4 text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 hover:text-violet-500 transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-slate-500 dark:text-slate-400">Loading…</p>
+        ) : displayed.length === 0 ? (
+          <div className="text-center py-16">
+            <p className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500 mb-2">No applications</p>
+            <p className="text-sm text-slate-500 dark:text-slate-400 font-light">
+              {hasFilters ? 'No applications match your filters.' : 'There are no pending loan applications.'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {displayed.map((app) => (
+              <ApplicationCard
+                key={app.id}
+                app={app}
+                onApprove={handleApprove}
+                onReject={handleReject}
+              />
+            ))}
+          </div>
+        )}
+
+      </div>
+
+      {toast && (
+        <div className={`fixed bottom-6 right-6 px-5 py-3 rounded-xl text-sm shadow-lg text-white transition-all ${
+          toast.type === 'success' ? 'bg-emerald-600' : 'bg-red-500'
+        }`}>
+          {toast.msg}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/employee/EmployeeLoansPage.jsx
+++ b/src/pages/employee/EmployeeLoansPage.jsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { employeeLoanService } from '../../services/loanService'
+import { fmt } from '../../utils/formatting'
+
+const LOAN_TYPES = ['CASH', 'HOUSING', 'AUTO', 'REFINANCING', 'STUDENT']
+const STATUSES   = ['PENDING', 'APPROVED', 'REJECTED', 'PAID_OFF', 'IN_DELAY']
+
+const LOAN_TYPE_LABELS = {
+  CASH: 'Cash', HOUSING: 'Housing', AUTO: 'Auto', REFINANCING: 'Refinancing', STUDENT: 'Student',
+}
+
+const STATUS_STYLES = {
+  PENDING:  'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400',
+  APPROVED: 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400',
+  REJECTED: 'bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400',
+  PAID_OFF: 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400',
+  IN_DELAY: 'bg-orange-50 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400',
+}
+
+function statusLabel(s) {
+  if (!s) return s
+  return s.charAt(0) + s.slice(1).toLowerCase().replace('_', ' ')
+}
+
+export default function EmployeeLoansPage() {
+  useWindowTitle('All Loans | AnkaBanka')
+
+  const [loans, setLoans]     = useState([])
+  const [loading, setLoading] = useState(true)
+  const [filters, setFilters] = useState({ loanType: '', accountNumber: '', status: '' })
+
+  useEffect(() => {
+    employeeLoanService.getAllLoans()
+      .then((data) => setLoans([...data].sort((a, b) =>
+        (a.accountNumber ?? '').localeCompare(b.accountNumber ?? '')
+      )))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const displayed = loans.filter((l) => {
+    const typeMatch   = !filters.loanType || l.loanType === filters.loanType
+    const accMatch    = !filters.accountNumber.trim() ||
+      l.accountNumber?.toLowerCase().includes(filters.accountNumber.trim().toLowerCase())
+    const statusMatch = !filters.status || l.status === filters.status
+    return typeMatch && accMatch && statusMatch
+  })
+
+  const hasFilters = filters.loanType || filters.accountNumber || filters.status
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-1">All Loans</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-10" />
+
+        {/* Filters */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 mb-6 shadow-sm">
+          <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-4">Filter</p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <select
+              value={filters.loanType}
+              onChange={(e) => setFilters((p) => ({ ...p, loanType: e.target.value }))}
+              className="input-field"
+            >
+              <option value="">All loan types</option>
+              {LOAN_TYPES.map((t) => <option key={t} value={t}>{LOAN_TYPE_LABELS[t]}</option>)}
+            </select>
+            <input
+              type="text"
+              value={filters.accountNumber}
+              onChange={(e) => setFilters((p) => ({ ...p, accountNumber: e.target.value }))}
+              placeholder="Account number"
+              className="input-field"
+            />
+            <select
+              value={filters.status}
+              onChange={(e) => setFilters((p) => ({ ...p, status: e.target.value }))}
+              className="input-field"
+            >
+              <option value="">All statuses</option>
+              {STATUSES.map((s) => <option key={s} value={s}>{statusLabel(s)}</option>)}
+            </select>
+          </div>
+          {hasFilters && (
+            <button
+              onClick={() => setFilters({ loanType: '', accountNumber: '', status: '' })}
+              className="mt-4 text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 hover:text-violet-500 transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        {/* Table */}
+        {loading ? (
+          <p className="text-sm text-slate-500 dark:text-slate-400">Loading…</p>
+        ) : (
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Account', 'Loan Type', 'Int. Rate', 'Agreement', 'Period', 'Amount', 'Remaining', 'Status'].map((h) => (
+                      <th key={h} className="px-5 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {displayed.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="px-6 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                        {hasFilters ? 'No loans match your filters.' : 'No loans found.'}
+                      </td>
+                    </tr>
+                  ) : (
+                    displayed.map((loan, i) => (
+                      <tr
+                        key={loan.id}
+                        className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                          i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
+                        }`}
+                      >
+                        <td className="px-5 py-4 font-mono text-xs text-slate-700 dark:text-slate-300 whitespace-nowrap">
+                          {loan.accountNumber}
+                        </td>
+                        <td className="px-5 py-4 text-slate-700 dark:text-slate-300 whitespace-nowrap">
+                          {LOAN_TYPE_LABELS[loan.loanType] ?? loan.loanType}
+                        </td>
+                        <td className="px-5 py-4 text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                          {loan.interestRateType}
+                        </td>
+                        <td className="px-5 py-4 text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                          {loan.agreedDate ?? '—'}
+                        </td>
+                        <td className="px-5 py-4 text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                          {loan.repaymentPeriod ? `${loan.repaymentPeriod} mo` : '—'}
+                        </td>
+                        <td className="px-5 py-4 text-slate-700 dark:text-slate-300 whitespace-nowrap">
+                          {fmt(loan.amount, loan.currency)}
+                        </td>
+                        <td className="px-5 py-4 text-slate-700 dark:text-slate-300 whitespace-nowrap">
+                          {loan.remainingDebt != null ? fmt(loan.remainingDebt, loan.currency) : '—'}
+                        </td>
+                        <td className="px-5 py-4 whitespace-nowrap">
+                          <span className={`inline-flex items-center px-2.5 py-0.5 text-xs rounded-full ${STATUS_STYLES[loan.status] ?? STATUS_STYLES.PENDING}`}>
+                            {statusLabel(loan.status)}
+                          </span>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            {displayed.length > 0 && (
+              <div className="px-6 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+                Showing {displayed.length}{hasFilters ? ` result${displayed.length !== 1 ? 's' : ''}` : ` of ${loans.length} loans`}
+              </div>
+            )}
+          </div>
+        )}
+
+      </div>
+    </div>
+  )
+}

--- a/src/services/loanService.js
+++ b/src/services/loanService.js
@@ -1,4 +1,5 @@
 import { clientApiClient } from './clientApiClient'
+import { apiClient } from './apiClient'
 
 export const loanService = {
   async getMyLoans() {
@@ -12,7 +13,36 @@ export const loanService = {
   },
 
   async applyForLoan(payload) {
-    const { data } = await clientApiClient.post('/loans', payload)
+    const { data } = await clientApiClient.post('/loans/apply', payload)
+    return data
+  },
+}
+
+export const employeeLoanService = {
+  async getLoanApplications({ loanType, accountNumber } = {}) {
+    const params = {}
+    if (loanType)      params.loanType      = loanType
+    if (accountNumber) params.accountNumber = accountNumber
+    const { data } = await apiClient.get('/admin/loans/applications', { params })
+    return data
+  },
+
+  async approveLoan(id) {
+    const { data } = await apiClient.put(`/admin/loans/${id}/approve`)
+    return data
+  },
+
+  async rejectLoan(id) {
+    const { data } = await apiClient.put(`/admin/loans/${id}/reject`)
+    return data
+  },
+
+  async getAllLoans({ loanType, accountNumber, status } = {}) {
+    const params = {}
+    if (loanType)      params.loanType      = loanType
+    if (accountNumber) params.accountNumber = accountNumber
+    if (status)        params.status        = status
+    const { data } = await apiClient.get('/admin/loans', { params })
     return data
   },
 }


### PR DESCRIPTION
- EmployeeLoanApplicationsPage: list pending applications with per-card approve/reject (with confirmation step), filterable by loan type and account number
- EmployeeLoansPage: all loans table sortable by account number, filterable by loan type, account number, and status
- employeeLoanService: getLoanApplications, approveLoan, rejectLoan, getAllLoans (employee API endpoints)
- Fix applyForLoan endpoint: POST /loans/apply (was /loans)
- Navbar: add Loan Applications and Loans links for logged-in employees