### PR TITLE
fix: account subtype display, card currency labels, and default limits

### DIFF
--- a/src/models/BankAccount.js
+++ b/src/models/BankAccount.js
@@ -77,6 +77,12 @@ export class BankAccount {
   }
 }
 
+// Formats a raw accountType string for display (e.g. "foreign_currency" → "Foreign Currency")
+export function formatAccountType(type) {
+  if (!type) return '—'
+  return type.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+}
+
 // ─── Subtype labels ───────────────────────────────────────────────────────────
 
 export const PERSONAL_SUBTYPES = [
@@ -107,7 +113,7 @@ export function bankAccountFromApi(data) {
     createdByEmployeeId: data.employeeId  ?? null,
     currency:         data.currency ?? data.currencyCode ?? 'RSD',
     type:             data.accountType?.toUpperCase() === 'BUSINESS' ? 'business' : 'personal',
-    subtype:          data.accountType ? data.accountType.toLowerCase() : null,
+    subtype:          data.accountSubtype ?? (data.accountType ? data.accountType.toLowerCase() : null),
     status:           data.status ? data.status.toLowerCase() : 'active',
     balance:          data.balance        ?? 0,
     availableBalance: data.availableBalance ?? 0,

--- a/src/pages/employee/AccountDetailPage.jsx
+++ b/src/pages/employee/AccountDetailPage.jsx
@@ -4,7 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAccounts } from '../../context/AccountsContext'
 import { accountService } from '../../services/accountService'
 import { employeeCardService } from '../../services/cardService'
-import { BankAccount } from '../../models/BankAccount'
+import { BankAccount, formatAccountType } from '../../models/BankAccount'
 import { fmt } from '../../utils/formatting'
 import Spinner from '../../components/Spinner'
 import CardBrand from '../../components/CardBrand'
@@ -177,7 +177,7 @@ export default function AccountDetailPage() {
               {account.type === 'personal' ? 'Personal' : 'Business'}
             </span>
           } />
-          <Row label="Subtype"  value={account.subtype ?? '—'} />
+          <Row label="Subtype"  value={formatAccountType(account.subtype)} />
           <Row label="Currency" value={account.currency} />
           <Row label="Currency Type" value={
             <span className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium tracking-wide rounded-full ${
@@ -271,7 +271,7 @@ export default function AccountDetailPage() {
 
         {/* Cards */}
         {account.accountNumber && (
-          <AccountCards accountNumber={account.accountNumber} />
+          <AccountCards accountNumber={account.accountNumber} currency={account.currency} />
         )}
 
       </div>
@@ -285,7 +285,7 @@ const CARD_STATUS_STYLES = {
   DEACTIVATED: 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400',
 }
 
-function AccountCards({ accountNumber }) {
+function AccountCards({ accountNumber, currency = 'RSD' }) {
   const { addSuccess } = useApiError()
   const [cards, setCards]           = useState(null) // null = loading
   const [error, setError]           = useState(false)
@@ -316,6 +316,7 @@ function AccountCards({ accountNumber }) {
               <EmployeeCardRow
                 key={card.cardNumber}
                 card={card}
+                currency={currency}
                 onUpdate={updateCard}
                 addSuccess={addSuccess}
                 onClick={() => setSelectedCard(card)}
@@ -333,6 +334,7 @@ function AccountCards({ accountNumber }) {
           actions={
             <EmployeeCardActions
               card={selectedCard}
+              currency={currency}
               onUpdate={(updated) => { updateCard(updated); setSelectedCard(null) }}
               addSuccess={addSuccess}
             />
@@ -343,7 +345,7 @@ function AccountCards({ accountNumber }) {
   )
 }
 
-function EmployeeCardRow({ card, onUpdate, addSuccess, onClick }) {
+function EmployeeCardRow({ card, currency = 'RSD', onUpdate, addSuccess, onClick }) {
   const [busy, setBusy]                           = useState(false)
   const [confirmDeactivate, setConfirmDeactivate] = useState(false)
   const [editingLimit, setEditingLimit]           = useState(false)
@@ -470,7 +472,7 @@ function EmployeeCardRow({ card, onUpdate, addSuccess, onClick }) {
                 step="1"
                 className={`input-field py-1 text-xs w-36 pr-10 ${limitError ? 'input-error' : ''}`}
               />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 pointer-events-none">RSD</span>
+              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 pointer-events-none">{currency}</span>
             </div>
             {limitError && <p className="text-xs text-red-500">{limitError}</p>}
             <button onClick={handleSaveLimit} disabled={limitBusy}
@@ -485,7 +487,7 @@ function EmployeeCardRow({ card, onUpdate, addSuccess, onClick }) {
         ) : (
           <>
             <span className="text-xs text-slate-400 dark:text-slate-500">
-              Limit: <span className="text-slate-600 dark:text-slate-300">{card.cardLimit.toLocaleString('sr-RS')} RSD</span>
+              Limit: <span className="text-slate-600 dark:text-slate-300">{card.cardLimit.toLocaleString('sr-RS')} {currency}</span>
             </span>
             {!card.isDeactivated && (
               <button onClick={() => { setLimitInput(String(card.cardLimit)); setEditingLimit(true) }}
@@ -500,7 +502,7 @@ function EmployeeCardRow({ card, onUpdate, addSuccess, onClick }) {
   )
 }
 
-function EmployeeCardActions({ card, onUpdate, addSuccess }) {
+function EmployeeCardActions({ card, currency = 'RSD', onUpdate, addSuccess }) {
   const [busy, setBusy]                           = useState(false)
   const [confirmDeactivate, setConfirmDeactivate] = useState(false)
   const [editingLimit, setEditingLimit]           = useState(false)
@@ -608,7 +610,7 @@ function EmployeeCardActions({ card, onUpdate, addSuccess }) {
         ) : (
           <>
             <span className="text-xs text-slate-400 dark:text-slate-500">
-              Limit: <span className="text-slate-600 dark:text-slate-300">{card.cardLimit.toLocaleString('sr-RS')} RSD</span>
+              Limit: <span className="text-slate-600 dark:text-slate-300">{card.cardLimit.toLocaleString('sr-RS')} {currency}</span>
             </span>
             <button onClick={() => { setLimitInput(String(card.cardLimit)); setEditingLimit(true) }}
               className="text-xs tracking-widest uppercase text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 transition-colors">

--- a/src/pages/employee/NewAccountPage.jsx
+++ b/src/pages/employee/NewAccountPage.jsx
@@ -5,6 +5,7 @@ import { useAccounts } from '../../context/AccountsContext'
 import { useClients } from '../../context/ClientsContext'
 import { useAuth } from '../../context/AuthContext'
 import { PERSONAL_SUBTYPES, BUSINESS_SUBTYPES } from '../../models/BankAccount'
+import { apiClient } from '../../services/apiClient'
 
 const FOREIGN_CURRENCIES = ['EUR', 'USD', 'GBP', 'CHF', 'JPY', 'CAD', 'AUD']
 
@@ -41,6 +42,28 @@ function defaultName(type, subtype) {
   return found ? `${found.label} Account` : ''
 }
 
+function defaultCardLimitRsd(type, subtype) {
+  if (type === 'business') {
+    return subtype === 'foundation' ? 100000 : 500000
+  }
+  switch (subtype) {
+    case 'standard':   return 250000
+    case 'savings':    return 50000
+    case 'pensioner':  return 50000
+    case 'youth':      return 25000
+    case 'student':    return 25000
+    case 'unemployed': return 10000
+    default:           return 250000
+  }
+}
+
+function toAccountCurrency(rsdAmount, currency, rates) {
+  if (!currency || currency === 'RSD') return String(rsdAmount)
+  const rate = rates.find(r => r.currencyCode === currency)?.sellingRate
+  if (!rate) return String(rsdAmount)
+  return String(Math.round(rsdAmount / rate / 50) * 50)
+}
+
 function defaultLimits(type, subtype) {
   if (type === 'business') {
     if (subtype === 'foundation') return { dailyLimit: '100000', monthlyLimit: '1000000' }
@@ -69,11 +92,14 @@ export default function NewAccountPage() {
   const [company, setCompany]   = useState(EMPTY_COMPANY)
   const [limits, setLimits]     = useState(EMPTY_LIMITS)
   const [createCard, setCreateCard] = useState(false)
+  const [cardLimit, setCardLimit]   = useState('')
+  const [exchangeRates, setExchangeRates] = useState([])
   const [errors, setErrors]     = useState({})
   const [success, setSuccess]   = useState(null)
 
   useEffect(() => {
     if (clients.length === 0) reloadClients()
+    apiClient.get('/exchange/rates').then(({ data }) => setExchangeRates(data)).catch(() => {})
   }, [])
 
   function handleChange(e) {
@@ -100,16 +126,43 @@ export default function NewAccountPage() {
         subtype:     value,
         accountName: defaultName(prev.type, value),
       }))
-      setLimits(defaultLimits(form.type, value))
+      const rsdLimits = defaultLimits(form.type, value)
+      setLimits({
+        dailyLimit:   toAccountCurrency(parseFloat(rsdLimits.dailyLimit),   form.currency, exchangeRates),
+        monthlyLimit: toAccountCurrency(parseFloat(rsdLimits.monthlyLimit), form.currency, exchangeRates),
+      })
+      setCardLimit(toAccountCurrency(defaultCardLimitRsd(form.type, value), form.currency, exchangeRates))
       return
     }
 
     if (name === 'currencyType') {
+      const newCurrency = value === 'current' ? 'RSD' : ''
       setForm((prev) => ({
         ...prev,
         currencyType: value,
-        currency:     value === 'current' ? 'RSD' : '',
+        currency:     newCurrency,
       }))
+      if (form.subtype) {
+        const rsdLimits = defaultLimits(form.type, form.subtype)
+        setLimits({
+          dailyLimit:   toAccountCurrency(parseFloat(rsdLimits.dailyLimit),   newCurrency, exchangeRates),
+          monthlyLimit: toAccountCurrency(parseFloat(rsdLimits.monthlyLimit), newCurrency, exchangeRates),
+        })
+      }
+      setCardLimit(toAccountCurrency(defaultCardLimitRsd(form.type, form.subtype), newCurrency, exchangeRates))
+      return
+    }
+
+    if (name === 'currency') {
+      setForm((prev) => ({ ...prev, currency: value }))
+      if (form.subtype) {
+        const rsdLimits = defaultLimits(form.type, form.subtype)
+        setLimits({
+          dailyLimit:   toAccountCurrency(parseFloat(rsdLimits.dailyLimit),   value, exchangeRates),
+          monthlyLimit: toAccountCurrency(parseFloat(rsdLimits.monthlyLimit), value, exchangeRates),
+        })
+      }
+      setCardLimit(toAccountCurrency(defaultCardLimitRsd(form.type, form.subtype), value, exchangeRates))
       return
     }
 
@@ -147,6 +200,11 @@ export default function NewAccountPage() {
     if (!limits.monthlyLimit || isNaN(monthly) || monthly <= 0) errs.monthlyLimit = true
     if (!errs.dailyLimit && !errs.monthlyLimit && daily > monthly) errs.dailyLimit = true
 
+    if (createCard) {
+      const cl = parseFloat(cardLimit)
+      if (!cardLimit || isNaN(cl) || cl <= 0) errs.cardLimit = true
+    }
+
     return errs
   }
 
@@ -171,6 +229,7 @@ export default function NewAccountPage() {
         dailyLimit:          parseFloat(limits.dailyLimit),
         monthlyLimit:        parseFloat(limits.monthlyLimit),
         createCard,
+        ...(createCard && { cardLimit: parseFloat(cardLimit) }),
         ...(form.type === 'business' && {
           companyData: {
             name:               company.name.trim(),
@@ -498,7 +557,7 @@ export default function NewAccountPage() {
                     className={`input-field pr-14${errors.dailyLimit ? ' input-error' : ''}`}
                   />
                   <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 dark:text-slate-500 pointer-events-none">
-                    RSD
+                    {form.currency || 'RSD'}
                   </span>
                 </div>
               </Field>
@@ -516,7 +575,7 @@ export default function NewAccountPage() {
                     className={`input-field pr-14${errors.monthlyLimit ? ' input-error' : ''}`}
                   />
                   <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 dark:text-slate-500 pointer-events-none">
-                    RSD
+                    {form.currency || 'RSD'}
                   </span>
                 </div>
               </Field>
@@ -538,6 +597,19 @@ export default function NewAccountPage() {
             <p className="mt-2 ml-7 text-xs text-slate-400 dark:text-slate-500">
               A card will be automatically generated — no email confirmation required.
             </p>
+            {createCard && (
+              <div className="mt-4 ml-7">
+                <Field label={`Card Limit (${form.currency || 'RSD'})`} error={errors.cardLimit}>
+                  <input
+                    type="number"
+                    value={cardLimit}
+                    onChange={(e) => { setErrors((p) => ({ ...p, cardLimit: false })); setCardLimit(e.target.value) }}
+                    className={`input-field ${errors.cardLimit ? 'input-error' : ''}`}
+                    min="1"
+                  />
+                </Field>
+              </div>
+            )}
           </div>
 
           {errors._submit && (

--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -22,7 +22,7 @@ export const accountService = {
     return bankAccountFromApi({ id, ...data })
   },
 
-  async createAccount({ ownerId, ownerFirstName, ownerLastName, type, subtype, accountName, currencyType, currency, companyData, dailyLimit, monthlyLimit, createCard }) {
+  async createAccount({ ownerId, ownerFirstName, ownerLastName, type, subtype, accountName, currencyType, currency, companyData, dailyLimit, monthlyLimit, createCard, cardLimit }) {
     let accountType
     if (currencyType === 'foreign') {
       accountType = 'FOREIGN_CURRENCY'
@@ -34,14 +34,16 @@ export const accountService = {
       accountType = 'CURRENT'
     }
     const { data } = await apiClient.post('/api/accounts/create', {
-      clientId:     ownerId,
+      clientId:       ownerId,
       accountType,
+      accountSubtype: subtype,
       accountName,
-      currencyCode: currency,
+      currencyCode:   currency,
       ...(companyData  && { companyData }),
       ...(dailyLimit   && { dailyLimit }),
       ...(monthlyLimit && { monthlyLimit }),
       ...(createCard   && { createCard: true }),
+      ...(createCard && cardLimit && { cardLimit }),
     })
     return bankAccountFromApi({ ownerFirstName, ownerLastName, ...data })
   },


### PR DESCRIPTION
- Read accountSubtype from API response for correct subtype display (student, doo, etc.)
- Pass currency prop through AccountCards/EmployeeCardRow/EmployeeCardActions to fix hardcoded RSD labels
- Set default card and transaction limits in account currency using live exchange rates
- Send accountSubtype in account creation request