### PR TITLE
feat(recipients): persist drag-and-drop reorder (#69)

### DIFF
--- a/src/context/RecipientsContext.jsx
+++ b/src/context/RecipientsContext.jsx
@@ -40,8 +40,9 @@ export function RecipientsProvider({ children }) {
     setRecipients((prev) => prev.filter((r) => r.id !== id))
   }
 
-  function reorderRecipients(newList) {
+  async function reorderRecipients(newList) {
     setRecipients(newList)
+    await recipientService.reorderRecipients(newList.map((r) => r.id))
   }
 
   useEffect(() => { if (clientUser) reload() }, [clientUser])

--- a/src/services/recipientService.js
+++ b/src/services/recipientService.js
@@ -20,4 +20,8 @@ export const recipientService = {
   async deleteRecipient(id) {
     await clientApiClient.delete(`/api/recipients/${id}`)
   },
+
+  async reorderRecipients(orderedIds) {
+    await clientApiClient.put('/api/recipients/reorder', { orderedIds })
+  },
 }


### PR DESCRIPTION
- Add reorderRecipients() to recipientService (PUT /api/recipients/reorder)
- RecipientsContext.reorderRecipients now persists order to backend after local state update