### PR TITLE
feat: dockerize frontend and fix API gateway URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+ARG VITE_API_URL=http://localhost:8083
+ENV VITE_API_URL=$VITE_API_URL
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/src/pages/client/ClientActivatePage.jsx
+++ b/src/pages/client/ClientActivatePage.jsx
@@ -3,7 +3,7 @@ import { useSearchParams, Link } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import axios from 'axios'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8081'
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
 
 const MIN_LENGTH = 8
 const MAX_LENGTH = 32

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -15,7 +15,7 @@
 import axios from 'axios'
 import { tokenService } from './tokenService'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8081'
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
 
 // ── Bare client used only for token refresh ─────────────────────────────────
 // No interceptors — prevents infinite 401 loop if the refresh endpoint itself

--- a/src/services/clientApiClient.js
+++ b/src/services/clientApiClient.js
@@ -9,7 +9,7 @@
 import axios from 'axios'
 import { clientTokenService } from './clientTokenService'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8081'
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
 
 // Bare client used only for the refresh call — no interceptors to avoid loops.
 export const clientRefreshAxios = axios.create({ baseURL: BASE_URL })

--- a/src/services/clientAuthService.js
+++ b/src/services/clientAuthService.js
@@ -8,7 +8,7 @@
 import axios from 'axios'
 import { clientTokenService } from './clientTokenService'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8081'
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
 
 function decodeJwtPayload(token) {
   const payload = token.split('.')[1]


### PR DESCRIPTION
Add multi-stage Dockerfile (node:20-alpine builder + nginx:alpine runtime) with VITE_API_URL build arg. Fix hardcoded fallback URLs from localhost:8081 to localhost:8083 in all API client files.