### PR TITLE
feat: role-based permissions system overhaul

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -15,8 +15,6 @@ function Navbar() {
     setMenuOpen(false)
   }
 
-  const isAdmin = user?.roles?.includes('ADMIN')
-
   const linkClass = ({ isActive }) =>
     `relative text-xs tracking-widest uppercase font-medium pb-1 transition-colors duration-150 ${
       isActive
@@ -41,28 +39,28 @@ function Navbar() {
           {/* Desktop links */}
           <div className="hidden md:flex items-center gap-8">
             <NavLink to="/" className={linkClass} end>Home</NavLink>
-            {user?.roles?.includes('ADMIN') && (
+            {user?.permissions?.canManageEmployees && (
               <NavLink to="/admin/employees" className={linkClass}>Employees</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canViewClients) && (
+            {user?.permissions?.canViewClients && (
               <NavLink to="/admin/clients" className={linkClass}>Clients</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canViewClients) && (
+            {user?.permissions?.canViewClients && (
               <NavLink to="/admin/accounts" className={linkClass}>Accounts</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canCreateAccounts) && (
+            {user?.permissions?.isAdmin && (
               <NavLink to="/admin/bank-accounts" className={linkClass}>Bank Accounts</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canApproveLoans) && (
+            {user?.permissions?.canApproveLoans && (
               <NavLink to="/admin/loans/applications" className={linkClass}>Loan Applications</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canApproveLoans) && (
+            {user?.permissions?.canApproveLoans && (
               <NavLink to="/admin/loans" className={linkClass}>Loans</NavLink>
             )}
-            {(isAdmin || user?.permissions?.isSupervisor) && (
+            {user?.permissions?.isSupervisor && (
               <NavLink to="/admin/actuaries" className={linkClass}>Actuaries</NavLink>
             )}
-            {user && (
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
               <NavLink to="/admin/stock-exchanges" className={linkClass}>Stock Exchanges</NavLink>
             )}
           </div>
@@ -121,28 +119,28 @@ function Navbar() {
         {menuOpen && (
           <div className="md:hidden border-t border-slate-100 dark:border-slate-800 py-4 flex flex-col gap-4">
             <NavLink to="/" className={linkClass} end onClick={() => setMenuOpen(false)}>Home</NavLink>
-            {user?.roles?.includes('ADMIN') && (
+            {user?.permissions?.canManageEmployees && (
               <NavLink to="/admin/employees" className={linkClass} onClick={() => setMenuOpen(false)}>Employees</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canViewClients) && (
+            {user?.permissions?.canViewClients && (
               <NavLink to="/admin/clients" className={linkClass} onClick={() => setMenuOpen(false)}>Clients</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canViewClients) && (
+            {user?.permissions?.canViewClients && (
               <NavLink to="/admin/accounts" className={linkClass} onClick={() => setMenuOpen(false)}>Accounts</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canCreateAccounts) && (
+            {user?.permissions?.isAdmin && (
               <NavLink to="/admin/bank-accounts" className={linkClass} onClick={() => setMenuOpen(false)}>Bank Accounts</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canApproveLoans) && (
+            {user?.permissions?.canApproveLoans && (
               <NavLink to="/admin/loans/applications" className={linkClass} onClick={() => setMenuOpen(false)}>Loan Applications</NavLink>
             )}
-            {(isAdmin || user?.permissions?.canApproveLoans) && (
+            {user?.permissions?.canApproveLoans && (
               <NavLink to="/admin/loans" className={linkClass} onClick={() => setMenuOpen(false)}>Loans</NavLink>
             )}
-            {(isAdmin || user?.permissions?.isSupervisor) && (
+            {user?.permissions?.isSupervisor && (
               <NavLink to="/admin/actuaries" className={linkClass} onClick={() => setMenuOpen(false)}>Actuaries</NavLink>
             )}
-            {user && (
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
               <NavLink to="/admin/stock-exchanges" className={linkClass} onClick={() => setMenuOpen(false)}>Stock Exchanges</NavLink>
             )}
             <div className="flex items-center gap-4">

--- a/src/models/ActuaryInfo.js
+++ b/src/models/ActuaryInfo.js
@@ -6,14 +6,26 @@
 export class ActuaryInfo {
   constructor({
     employeeId,   // number  — links to Employee.id
+    firstName,    // string
+    lastName,     // string
+    email,        // string
+    position,     // string
     limit,        // number  — spending limit in RSD (null for supervisors)
     usedLimit,    // number  — amount used so far in RSD
     needApproval, // boolean — whether transactions require supervisor approval
   }) {
     this.employeeId   = employeeId
+    this.firstName    = firstName ?? ''
+    this.lastName     = lastName  ?? ''
+    this.email        = email     ?? ''
+    this.position     = position  ?? ''
     this.limit        = limit
     this.usedLimit    = usedLimit
     this.needApproval = needApproval
+  }
+
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`
   }
 }
 
@@ -22,9 +34,13 @@ export class ActuaryInfo {
  */
 export function actuaryInfoFromApi(data) {
   return new ActuaryInfo({
-    employeeId:   data.employee_id ?? data.employeeId,
+    employeeId:   data.employee_id  ?? data.employeeId,
+    firstName:    data.first_name   ?? data.firstName,
+    lastName:     data.last_name    ?? data.lastName,
+    email:        data.email,
+    position:     data.position,
     limit:        data.limit,
-    usedLimit:    data.used_limit  ?? data.usedLimit,
+    usedLimit:    data.used_limit   ?? data.usedLimit,
     needApproval: data.need_approval ?? data.needApproval,
   })
 }

--- a/src/models/Employee.js
+++ b/src/models/Employee.js
@@ -76,8 +76,8 @@ export class Employee {
   }
 }
 
-// Maps frontend permission keys to their backend dozvole string equivalents.
-const DOZVOLE_MAP = {
+// Maps frontend permission keys to their backend JWT claim string equivalents.
+const PERMISSION_CLAIM_MAP = {
   isAdmin:                'ADMIN',
   canViewClients:         'READ',
   canCreateAccounts:      'WRITE',
@@ -90,20 +90,20 @@ const DOZVOLE_MAP = {
 }
 
 /**
- * Convert a dozvole string array (backend) to a permissions boolean object (frontend).
+ * Convert a permission claims array (from backend JWT) to a permissions boolean object (frontend).
  */
-export function permissionsFromDozvole(dozvole = []) {
-  const upper = dozvole.map((d) => d.toUpperCase())
+export function permissionsFromClaims(claims = []) {
+  const upper = claims.map((c) => c.toUpperCase())
   return Object.fromEntries(
-    Object.entries(DOZVOLE_MAP).map(([key, str]) => [key, upper.includes(str)])
+    Object.entries(PERMISSION_CLAIM_MAP).map(([key, str]) => [key, upper.includes(str)])
   )
 }
 
 /**
- * Convert a permissions boolean object (frontend) back to a dozvole string array (backend).
+ * Convert a permissions boolean object (frontend) back to a permission claims array (backend).
  */
-export function dozvoleFromPermissions(permissions = {}) {
-  return Object.entries(DOZVOLE_MAP)
+export function claimsFromPermissions(permissions = {}) {
+  return Object.entries(PERMISSION_CLAIM_MAP)
     .filter(([key]) => permissions[key])
     .map(([, str]) => str)
 }
@@ -128,7 +128,7 @@ export function employeeFromApi(data) {
     position:     data.position,
     department:   data.department,
     active:       data.active,
-    permissions:  permissionsFromDozvole(data.permissions),
+    permissions:  permissionsFromClaims(data.permissions),
     jmbg:         data.jmbg,
   })
 }

--- a/src/pages/employee/ActuaryManagementPage.jsx
+++ b/src/pages/employee/ActuaryManagementPage.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import useWindowTitle from '../../hooks/useWindowTitle'
-import { useEmployees } from '../../context/EmployeesContext'
 import { actuaryService } from '../../services/actuaryService'
 import { fmt } from '../../utils/formatting'
 import PermissionGate from '../../components/PermissionGate'
@@ -10,41 +9,31 @@ const EMPTY_FILTERS = { firstName: '', lastName: '', email: '', position: '' }
 
 export default function ActuaryManagementPage() {
   useWindowTitle('Actuaries | AnkaBanka Admin')
-  const { employees, loading: empLoading, reload } = useEmployees()
 
   const [actuaries, setActuaries] = useState([])
+  const [loading, setLoading] = useState(true)
   const [filters, setFilters] = useState(EMPTY_FILTERS)
   const [editingLimit, setEditingLimit] = useState(null) // { agentId, value }
-
-  useEffect(() => {
-    if (employees.length === 0 && !empLoading) reload()
-  }, [])
 
   useEffect(() => {
     actuaryService.getActuaries()
       .then(setActuaries)
       .catch(() => {})
+      .finally(() => setLoading(false))
   }, [])
-
-  const agents = employees.filter((e) => e.permissions?.isAgent)
-
-  const rows = agents.map((emp) => ({
-    emp,
-    info: actuaries.find((a) => a.employeeId === emp.id) ?? null,
-  }))
 
   const hasFilters = Object.values(filters).some(Boolean)
   const displayed = hasFilters
-    ? rows.filter(({ emp }) => {
+    ? actuaries.filter((a) => {
         const f = filters
         return (
-          (!f.firstName || emp.firstName.toLowerCase().includes(f.firstName.toLowerCase())) &&
-          (!f.lastName  || emp.lastName.toLowerCase().includes(f.lastName.toLowerCase()))   &&
-          (!f.email     || emp.email.toLowerCase().includes(f.email.toLowerCase()))         &&
-          (!f.position  || emp.position.toLowerCase().includes(f.position.toLowerCase()))
+          (!f.firstName || a.firstName.toLowerCase().includes(f.firstName.toLowerCase())) &&
+          (!f.lastName  || a.lastName.toLowerCase().includes(f.lastName.toLowerCase()))   &&
+          (!f.email     || a.email.toLowerCase().includes(f.email.toLowerCase()))         &&
+          (!f.position  || a.position.toLowerCase().includes(f.position.toLowerCase()))
         )
       })
-    : rows
+    : actuaries
 
   function handleFilter(e) {
     setFilters((prev) => ({ ...prev, [e.target.name]: e.target.value }))
@@ -135,7 +124,7 @@ export default function ActuaryManagementPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {empLoading ? (
+                  {loading ? (
                     <tr>
                       <td colSpan={6} className="px-6 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
                         Loading…
@@ -148,27 +137,27 @@ export default function ActuaryManagementPage() {
                       </td>
                     </tr>
                   ) : (
-                    displayed.map(({ emp, info }, i) => (
+                    displayed.map((actuary, i) => (
                       <tr
-                        key={emp.id}
+                        key={actuary.employeeId}
                         className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
                           i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
                         }`}
                       >
                         <td className="px-6 py-4 text-slate-900 dark:text-white font-medium whitespace-nowrap">
-                          {emp.fullName}
+                          {actuary.fullName}
                         </td>
-                        <td className="px-6 py-4 text-slate-600 dark:text-slate-300">{emp.email}</td>
-                        <td className="px-6 py-4 text-slate-600 dark:text-slate-300">{emp.position}</td>
+                        <td className="px-6 py-4 text-slate-600 dark:text-slate-300">{actuary.email}</td>
+                        <td className="px-6 py-4 text-slate-600 dark:text-slate-300">{actuary.position}</td>
                         <td className="px-6 py-4 text-slate-900 dark:text-white whitespace-nowrap">
-                          {info != null ? fmt(info.limit, 'RSD') : '—'}
+                          {actuary.limit != null ? fmt(actuary.limit, 'RSD') : '—'}
                         </td>
                         <td className="px-6 py-4 text-slate-900 dark:text-white whitespace-nowrap">
-                          {info != null ? fmt(info.usedLimit, 'RSD') : '—'}
+                          {actuary.usedLimit != null ? fmt(actuary.usedLimit, 'RSD') : '—'}
                         </td>
                         <td className="px-6 py-4">
                           <div className="flex items-center gap-3 flex-wrap">
-                            {editingLimit?.agentId === emp.id ? (
+                            {editingLimit?.agentId === actuary.employeeId ? (
                               <div className="flex items-center gap-2">
                                 <input
                                   type="number"
@@ -176,12 +165,12 @@ export default function ActuaryManagementPage() {
                                   step="0.01"
                                   value={editingLimit.value}
                                   onChange={(e) => setEditingLimit((prev) => ({ ...prev, value: e.target.value }))}
-                                  onKeyDown={(e) => { if (e.key === 'Enter') handleSetLimit(emp.id); if (e.key === 'Escape') setEditingLimit(null) }}
+                                  onKeyDown={(e) => { if (e.key === 'Enter') handleSetLimit(actuary.employeeId); if (e.key === 'Escape') setEditingLimit(null) }}
                                   className="input-field w-32 text-sm"
                                   autoFocus
                                 />
                                 <button
-                                  onClick={() => handleSetLimit(emp.id)}
+                                  onClick={() => handleSetLimit(actuary.employeeId)}
                                   className="text-xs tracking-widest uppercase text-emerald-600 dark:text-emerald-400 hover:text-emerald-500 transition-colors"
                                 >
                                   Save
@@ -195,14 +184,14 @@ export default function ActuaryManagementPage() {
                               </div>
                             ) : (
                               <button
-                                onClick={() => setEditingLimit({ agentId: emp.id, value: info?.limit ?? '' })}
+                                onClick={() => setEditingLimit({ agentId: actuary.employeeId, value: actuary.limit ?? '' })}
                                 className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 hover:text-violet-500 transition-colors"
                               >
                                 Set limit
                               </button>
                             )}
                             <button
-                              onClick={() => handleResetUsedLimit(emp.id)}
+                              onClick={() => handleResetUsedLimit(actuary.employeeId)}
                               className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 transition-colors"
                             >
                               Reset used
@@ -215,9 +204,9 @@ export default function ActuaryManagementPage() {
                 </tbody>
               </table>
             </div>
-            {!empLoading && displayed.length > 0 && (
+            {!loading && displayed.length > 0 && (
               <div className="px-6 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
-                Showing {displayed.length}{hasFilters ? ` result${displayed.length !== 1 ? 's' : ''}` : ` of ${agents.length} agents`}
+                Showing {displayed.length}{hasFilters ? ` result${displayed.length !== 1 ? 's' : ''}` : ` of ${actuaries.length} agents`}
               </div>
             )}
           </div>

--- a/src/pages/employee/EmployeeDetailPage.jsx
+++ b/src/pages/employee/EmployeeDetailPage.jsx
@@ -2,9 +2,73 @@ import { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useEmployees } from '../../context/EmployeesContext'
-import { PERMISSIONS } from '../../models/Employee'
+import { DEFAULT_PERMISSIONS } from '../../models/Employee'
 import { actuaryService } from '../../services/actuaryService'
 import { fmt } from '../../utils/formatting'
+
+// ── Role definitions ──────────────────────────────────────────────────────────
+
+const ROLE_OPTIONS = [
+  {
+    key:         'none',
+    label:       'None',
+    description: 'No system access',
+  },
+  {
+    key:         'clerk',
+    label:       'Clerk',
+    description: 'Clients, Accounts',
+  },
+  {
+    key:         'creditAnalyst',
+    label:       'Credit Analyst',
+    description: 'Clients, Accounts, Loans',
+  },
+  {
+    key:         'agent',
+    label:       'Agent',
+    description: 'Stock Exchanges',
+  },
+  {
+    key:         'supervisor',
+    label:       'Supervisor',
+    description: 'Actuaries, Stock Exchanges',
+  },
+  {
+    key:         'admin',
+    label:       'Admin',
+    description: 'Full system access',
+  },
+]
+
+const ROLE_PERMISSIONS = {
+  none:         { ...DEFAULT_PERMISSIONS },
+  clerk:        { ...DEFAULT_PERMISSIONS, canViewClients: true },
+  creditAnalyst:{ ...DEFAULT_PERMISSIONS, canViewClients: true, canApproveLoans: true },
+  agent:        { ...DEFAULT_PERMISSIONS, isAgent: true },
+  supervisor:   { ...DEFAULT_PERMISSIONS, isSupervisor: true },
+  admin:        Object.fromEntries(Object.keys(DEFAULT_PERMISSIONS).map((k) => [k, true])),
+}
+
+const ROLE_STYLES = {
+  admin:        { badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400',  radio: 'accent-amber-600'  },
+  supervisor:   { badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400',      radio: 'accent-blue-600'   },
+  agent:        { badge: 'bg-violet-100 text-violet-700 dark:bg-violet-900/50 dark:text-violet-400', radio: 'accent-violet-600' },
+  creditAnalyst:{ badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400', radio: 'accent-emerald-600' },
+  clerk:        { badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400', radio: 'accent-emerald-600' },
+  none:         { badge: 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400',     radio: 'accent-slate-400'  },
+}
+
+function resolveRole(permissions) {
+  if (permissions?.isAdmin)         return 'admin'
+  if (permissions?.isSupervisor)    return 'supervisor'
+  if (permissions?.isAgent)         return 'agent'
+  if (permissions?.canApproveLoans) return 'creditAnalyst'
+  if (permissions?.canViewClients)  return 'clerk'
+  return 'none'
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function EmployeeDetailPage() {
   const { id } = useParams()
@@ -18,8 +82,11 @@ export default function EmployeeDetailPage() {
 
   useWindowTitle(emp ? `${emp.fullName} | AnkaBanka` : 'Employee | AnkaBanka')
 
-  const [editing, setEditing] = useState(false)
-  const [form, setForm] = useState({})
+  const [editing, setEditing]       = useState(false)
+  const [form, setForm]             = useState({})
+  const [selectedRole, setSelectedRole] = useState('none')
+  const [adminConfirm, setAdminConfirm] = useState(false)
+  const [pendingRole, setPendingRole]   = useState(null)
 
   const [actuaryInfo, setActuaryInfo] = useState(null)
   useEffect(() => {
@@ -41,6 +108,7 @@ export default function EmployeeDetailPage() {
   }
 
   function startEdit() {
+    const role = resolveRole(emp.permissions)
     setForm({
       firstName:   emp.firstName,
       lastName:    emp.lastName,
@@ -56,6 +124,7 @@ export default function EmployeeDetailPage() {
       active:      emp.active,
       permissions: { ...emp.permissions },
     })
+    setSelectedRole(role)
     setEditing(true)
   }
 
@@ -87,33 +156,29 @@ export default function EmployeeDetailPage() {
     if (errs[name]) setFieldErrors((prev) => ({ ...prev, [name]: errs[name] }))
   }
 
-  const [fieldErrors, setFieldErrors] = useState({})
-  const [adminConfirm, setAdminConfirm] = useState(false)
-  const [pendingAdminValue, setPendingAdminValue] = useState(false)
-
-  function handlePermissionChange(e) {
-    const { name, checked } = e.target
-    if (name === 'isAdmin' && checked) {
-      setPendingAdminValue(true)
+  function handleRoleChange(roleKey) {
+    if (roleKey === 'admin') {
+      setPendingRole(roleKey)
       setAdminConfirm(true)
       return
     }
-    setForm((prev) => {
-      const perms = { ...prev.permissions, [name]: checked }
-      if (name === 'isAgent' && checked)      perms.isSupervisor = false
-      if (name === 'isSupervisor' && checked) perms.isAgent = false
-      return { ...prev, permissions: perms }
-    })
+    setSelectedRole(roleKey)
+    setForm((prev) => ({ ...prev, permissions: { ...ROLE_PERMISSIONS[roleKey] } }))
   }
 
   function confirmAdmin() {
-    setForm((prev) => ({ ...prev, permissions: { ...prev.permissions, isAdmin: pendingAdminValue, isSupervisor: true } }))
+    setSelectedRole(pendingRole)
+    setForm((prev) => ({ ...prev, permissions: { ...ROLE_PERMISSIONS.admin } }))
     setAdminConfirm(false)
+    setPendingRole(null)
   }
 
   function cancelAdmin() {
     setAdminConfirm(false)
+    setPendingRole(null)
   }
+
+  const [fieldErrors, setFieldErrors] = useState({})
 
   async function handleSave() {
     const errs = validate()
@@ -130,6 +195,9 @@ export default function EmployeeDetailPage() {
   function handleCancel() {
     setEditing(false)
   }
+
+  const viewRole = resolveRole(emp.permissions)
+  const viewRoleMeta = ROLE_OPTIONS.find((r) => r.key === viewRole)
 
   return (
     <>
@@ -199,49 +267,32 @@ export default function EmployeeDetailPage() {
                 </div>
               </Section>
 
-              <Section title="Permissions">
-                {/* Admin — visually separated */}
-                <div className="mb-3 rounded-lg border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 px-4 py-3 flex items-center justify-between">
-                  <div>
-                    <span className="text-xs tracking-widest uppercase text-amber-700 dark:text-amber-400 font-semibold">Admin</span>
-                    <p className="text-xs text-amber-600 dark:text-amber-500 mt-0.5">Full system access — grants all privileges</p>
-                  </div>
-                  <input
-                    type="checkbox"
-                    name="isAdmin"
-                    checked={form.permissions?.isAdmin ?? false}
-                    onChange={handlePermissionChange}
-                    className="w-4 h-4 accent-amber-600"
-                  />
+              <Section title="Role">
+                <div className="pt-1 space-y-2">
+                  {ROLE_OPTIONS.map((role) => (
+                    <label
+                      key={role.key}
+                      className={`flex items-center gap-3 px-4 py-3 rounded-lg border cursor-pointer transition-colors ${
+                        selectedRole === role.key
+                          ? 'border-violet-400 dark:border-violet-500 bg-violet-50 dark:bg-violet-900/20'
+                          : 'border-slate-200 dark:border-slate-700 hover:border-violet-300 dark:hover:border-violet-700'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="role"
+                        value={role.key}
+                        checked={selectedRole === role.key}
+                        onChange={() => handleRoleChange(role.key)}
+                        className={`w-4 h-4 ${ROLE_STYLES[role.key].radio}`}
+                      />
+                      <div>
+                        <span className="text-sm font-medium text-slate-900 dark:text-white">{role.label}</span>
+                        <span className="text-xs text-slate-500 dark:text-slate-400 ml-2">{role.description}</span>
+                      </div>
+                    </label>
+                  ))}
                 </div>
-                {/* Supervisor — visually separated */}
-                <div className="mb-3 rounded-lg border border-blue-300 dark:border-blue-600 bg-blue-50 dark:bg-blue-900/20 px-4 py-3 flex items-center justify-between">
-                  <div>
-                    <span className="text-xs tracking-widest uppercase text-blue-700 dark:text-blue-400 font-semibold">Supervisor</span>
-                    <p className="text-xs text-blue-600 dark:text-blue-500 mt-0.5">Manages agents and their limits</p>
-                  </div>
-                  <input
-                    type="checkbox"
-                    name="isSupervisor"
-                    checked={form.permissions?.isSupervisor ?? false}
-                    onChange={handlePermissionChange}
-                    disabled={form.permissions?.isAdmin ?? false}
-                    className="w-4 h-4 accent-blue-600 disabled:opacity-50"
-                  />
-                </div>
-                {/* Other permissions */}
-                {Object.entries(PERMISSIONS).filter(([key]) => key !== 'isAdmin' && key !== 'isSupervisor').map(([key, label]) => (
-                  <div key={key} className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
-                    <span className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400">{label}</span>
-                    <input
-                      type="checkbox"
-                      name={key}
-                      checked={form.permissions?.[key] ?? false}
-                      onChange={handlePermissionChange}
-                      className="w-4 h-4 accent-violet-600"
-                    />
-                  </div>
-                ))}
               </Section>
 
               <div className="flex gap-3 pt-4">
@@ -282,48 +333,16 @@ export default function EmployeeDetailPage() {
                 <Row label="Employee ID" value={String(emp.id)} />
               </Section>
 
-              <Section title="Permissions">
-                {/* Admin row */}
-                <div className="mb-3 rounded-lg border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 px-4 py-3 flex items-center justify-between">
-                  <div>
-                    <span className="text-xs tracking-widest uppercase text-amber-700 dark:text-amber-400 font-semibold">Admin</span>
-                    <p className="text-xs text-amber-600 dark:text-amber-500 mt-0.5">Full system access — grants all privileges</p>
-                  </div>
-                  <span className={`text-xs font-medium tracking-wide px-2 py-0.5 rounded-full ${
-                    emp.permissions?.isAdmin
-                      ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400'
-                      : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'
-                  }`}>
-                    {emp.permissions?.isAdmin ? 'Granted' : 'Denied'}
-                  </span>
-                </div>
-                {/* Supervisor row */}
-                <div className="mb-3 rounded-lg border border-blue-300 dark:border-blue-600 bg-blue-50 dark:bg-blue-900/20 px-4 py-3 flex items-center justify-between">
-                  <div>
-                    <span className="text-xs tracking-widest uppercase text-blue-700 dark:text-blue-400 font-semibold">Supervisor</span>
-                    <p className="text-xs text-blue-600 dark:text-blue-500 mt-0.5">Manages agents and their limits</p>
-                  </div>
-                  <span className={`text-xs font-medium tracking-wide px-2 py-0.5 rounded-full ${
-                    emp.permissions?.isSupervisor
-                      ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400'
-                      : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'
-                  }`}>
-                    {emp.permissions?.isSupervisor ? 'Granted' : 'Denied'}
-                  </span>
-                </div>
-                {/* Other permissions */}
-                {Object.entries(PERMISSIONS).filter(([key]) => key !== 'isAdmin' && key !== 'isSupervisor').map(([key, label]) => (
-                  <div key={key} className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
-                    <span className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400">{label}</span>
-                    <span className={`text-xs font-medium tracking-wide px-2 py-0.5 rounded-full ${
-                      emp.permissions?.[key]
-                        ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-                        : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'
-                    }`}>
-                      {emp.permissions?.[key] ? 'Granted' : 'Denied'}
+              <Section title="Role">
+                <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
+                  <span className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400">Role</span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-slate-400 dark:text-slate-500">{viewRoleMeta?.description}</span>
+                    <span className={`text-xs font-semibold tracking-wide px-2.5 py-1 rounded-full ${ROLE_STYLES[viewRole].badge}`}>
+                      {viewRoleMeta?.label}
                     </span>
                   </div>
-                ))}
+                </div>
               </Section>
 
               {(emp.permissions?.isAgent || emp.permissions?.isSupervisor) && (

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -7,7 +7,7 @@
 
 import { apiClient, refreshClient } from './apiClient'
 import { tokenService } from './tokenService'
-import { permissionsFromDozvole } from '../models/Employee'
+import { DEFAULT_PERMISSIONS, permissionsFromClaims } from '../models/Employee'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -21,17 +21,18 @@ function decodeJwtPayload(token) {
 }
 
 function buildUserPayload(claims) {
-  const dozvole = claims.dozvole ?? []
-  const roles = dozvole.map((d) => d.toUpperCase()).includes('ADMIN')
-    ? ['ADMIN']
-    : ['USER']
+  const permissionClaims = claims.dozvole ?? []
+  const upper = permissionClaims.map((c) => c.toUpperCase())
+  const isAdmin = upper.includes('ADMIN')
   return {
     id:          claims.user_id,
     firstName:   claims.first_name ?? '',
     lastName:    claims.last_name  ?? '',
     email:       claims.email      ?? '',
-    roles,
-    permissions: permissionsFromDozvole(dozvole),
+    roles:       isAdmin ? ['ADMIN'] : ['USER'],
+    permissions: isAdmin
+      ? Object.fromEntries(Object.keys(DEFAULT_PERMISSIONS).map((k) => [k, true]))
+      : permissionsFromClaims(permissionClaims),
   }
 }
 

--- a/src/services/employeeService.js
+++ b/src/services/employeeService.js
@@ -6,7 +6,7 @@
  */
 
 import { apiClient } from './apiClient'
-import { dozvoleFromPermissions } from '../models/Employee'
+import { claimsFromPermissions } from '../models/Employee'
 
 export const employeeService = {
   /**
@@ -82,7 +82,7 @@ export const employeeService = {
       position:      form.position,
       department:    form.department,
       active:        form.active,
-      permissions:   dozvoleFromPermissions(form.permissions),
+      permissions:   claimsFromPermissions(form.permissions),
       jmbg:          form.jmbg,
     }
     const { data } = await apiClient.put(`/employees/${id}`, body)


### PR DESCRIPTION
- Admin gets all permissions at login (no more isAdmin || checks)
- Clean role model: None/Clerk/Credit Analyst/Agent/Supervisor/Admin
- Navbar tabs gated by single permission per tab; Bank Accounts Admin-only
- EmployeeDetailPage: replace checkbox mess with role radio selector
- ActuaryManagementPage: remove useEmployees() dependency (was causing 403 for Supervisors); use /api/actuaries data which already includes employee details
- Rename Serbian identifiers (dozvole, DOZVOLE_MAP) to English