### PR TITLE
feat: add securitiesService, orderService, and Listing model (#148)

### DIFF
--- a/src/models/Listing.js
+++ b/src/models/Listing.js
@@ -1,0 +1,66 @@
+/**
+ * Listing model
+ *
+ * Represents a securities listing (stock, forex, futures, option).
+ */
+export class Listing {
+  constructor({
+    id,
+    ticker,
+    name,
+    type,
+    exchangeAcronym,
+    price,
+    ask,
+    bid,
+    volume,
+    changePercent,
+    maintenanceMargin,
+    initialMarginCost,
+    stockDetail,
+    forexDetail,
+    futuresDetail,
+    optionDetail,
+  }) {
+    this.id                 = id
+    this.ticker             = ticker             ?? ''
+    this.name               = name               ?? ''
+    this.type               = type               ?? ''
+    this.exchangeAcronym    = exchangeAcronym    ?? ''
+    this.price              = price              ?? 0
+    this.ask                = ask                ?? 0
+    this.bid                = bid                ?? 0
+    this.volume             = volume             ?? 0
+    this.changePercent      = changePercent      ?? 0
+    this.maintenanceMargin  = maintenanceMargin  ?? 0
+    this.initialMarginCost  = initialMarginCost  ?? 0
+    this.stockDetail        = stockDetail        ?? null
+    this.forexDetail        = forexDetail        ?? null
+    this.futuresDetail      = futuresDetail      ?? null
+    this.optionDetail       = optionDetail       ?? null
+  }
+}
+
+/**
+ * Creates a Listing instance from a raw API response object.
+ */
+export function listingFromApi(data) {
+  return new Listing({
+    id:                data.id,
+    ticker:            data.ticker,
+    name:              data.name,
+    type:              data.type,
+    exchangeAcronym:   data.exchange_acronym    ?? data.exchangeAcronym,
+    price:             data.price,
+    ask:               data.ask,
+    bid:               data.bid,
+    volume:            data.volume,
+    changePercent:     data.change_percent      ?? data.changePercent,
+    maintenanceMargin: data.maintenance_margin  ?? data.maintenanceMargin,
+    initialMarginCost: data.initial_margin_cost ?? data.initialMarginCost,
+    stockDetail:       data.stock_detail        ?? data.stockDetail        ?? null,
+    forexDetail:       data.forex_detail        ?? data.forexDetail        ?? null,
+    futuresDetail:     data.futures_detail      ?? data.futuresDetail      ?? null,
+    optionDetail:      data.option_detail       ?? data.optionDetail       ?? null,
+  })
+}

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -1,0 +1,74 @@
+import { apiClient } from './apiClient'
+
+export const orderService = {
+  /**
+   * Place a new order.
+   */
+  async createOrder({ assetId, quantity, direction, orderType, limitValue, stopValue, isAon, isMargin, accountId }) {
+    const { data } = await apiClient.post('/orders', {
+      asset_id:    assetId,
+      quantity,
+      direction,
+      order_type:  orderType,
+      limit_value: limitValue,
+      stop_value:  stopValue,
+      is_aon:      isAon,
+      is_margin:   isMargin,
+      account_id:  accountId,
+    })
+    return data
+  },
+
+  /**
+   * Fetch a list of orders with optional filters.
+   */
+  async getOrders({ status, assetId, page, pageSize } = {}) {
+    const params = {}
+    if (status)       params.status    = status
+    if (assetId)      params.asset_id  = assetId
+    if (page     != null) params.page      = page
+    if (pageSize != null) params.page_size = pageSize
+    const { data } = await apiClient.get('/orders', { params })
+    return data
+  },
+
+  /**
+   * Fetch a single order by ID.
+   */
+  async getOrderById(id) {
+    const { data } = await apiClient.get(`/orders/${id}`)
+    return data
+  },
+
+  /**
+   * Approve a pending order (supervisor action).
+   */
+  async approveOrder(id) {
+    const { data } = await apiClient.put(`/orders/${id}/approve`)
+    return data
+  },
+
+  /**
+   * Decline a pending order (supervisor action).
+   */
+  async declineOrder(id) {
+    const { data } = await apiClient.put(`/orders/${id}/decline`)
+    return data
+  },
+
+  /**
+   * Cancel an active order.
+   */
+  async cancelOrder(id) {
+    const { data } = await apiClient.delete(`/orders/${id}`)
+    return data
+  },
+
+  /**
+   * Cancel remaining unfilled portions of an order.
+   */
+  async cancelOrderPortions(id) {
+    const { data } = await apiClient.delete(`/orders/${id}/portions`)
+    return data
+  },
+}

--- a/src/services/securitiesService.js
+++ b/src/services/securitiesService.js
@@ -1,0 +1,45 @@
+import { apiClient } from './apiClient'
+import { listingFromApi } from '../models/Listing'
+
+export const securitiesService = {
+  /**
+   * Fetch paginated list of listings.
+   */
+  async getListings({ type, exchange, ticker, name, page, pageSize, sortBy, sortOrder } = {}) {
+    const params = {}
+    if (type)       params.type        = type
+    if (exchange)   params.exchange    = exchange
+    if (ticker)     params.ticker      = ticker
+    if (name)       params.name        = name
+    if (page        != null) params.page       = page
+    if (pageSize    != null) params.page_size  = pageSize
+    if (sortBy)     params.sort_by     = sortBy
+    if (sortOrder)  params.sort_order  = sortOrder
+    const { data } = await apiClient.get('/securities', { params })
+    return {
+      ...data,
+      items: (data.items ?? data).map(listingFromApi),
+    }
+  },
+
+  /**
+   * Fetch full listing detail including type-specific fields and 30-day history.
+   */
+  async getListingById(id) {
+    const { data } = await apiClient.get(`/securities/${id}`)
+    return listingFromApi(data)
+  },
+
+  /**
+   * Fetch daily price history for a listing within a date range.
+   * @param {string} from - YYYY-MM-DD
+   * @param {string} to   - YYYY-MM-DD
+   */
+  async getListingHistory(id, from, to) {
+    const params = {}
+    if (from) params.from = from
+    if (to)   params.to   = to
+    const { data } = await apiClient.get(`/securities/${id}/history`, { params })
+    return data
+  },
+}


### PR DESCRIPTION
API client layer for securities listings and orders, following existing service patterns.