### PR TITLE
feat: securities listings overview page (#142) — untested

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 COPY . .
 ARG VITE_API_URL=http://localhost:8083
 ENV VITE_API_URL=$VITE_API_URL

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "axios": "^1.13.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.2"
+    "react-router-dom": "^6.26.2",
+    "recharts": "^2.13.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,8 @@ import EmployeeLoanApplicationsPage from './pages/employee/EmployeeLoanApplicati
 import EmployeeLoansPage from './pages/employee/EmployeeLoansPage'
 import ActuaryManagementPage from './pages/employee/ActuaryManagementPage'
 import StockExchangesPage from './pages/employee/StockExchangesPage'
+import SecuritiesPage from './pages/securities/SecuritiesPage'
+import ClientSecuritiesPage from './pages/client/ClientSecuritiesPage'
 import NotFoundPage from './pages/NotFoundPage'
 
 function App() {
@@ -82,6 +84,7 @@ function App() {
               <Route path="/admin/loans" element={<EmployeeLoansPage />} />
               <Route path="/admin/actuaries" element={<ActuaryManagementPage />} />
               <Route path="/admin/stock-exchanges" element={<StockExchangesPage />} />
+              <Route path="/securities" element={<SecuritiesPage />} />
             </Route>
           </Route>
 
@@ -110,6 +113,7 @@ function App() {
           <Route path="/client/loans/apply" element={<ClientLoanApplyPage />} />
           <Route path="/client/loans/:id" element={<ClientLoanDetailPage />} />
           <Route path="/client/recipients" element={<ClientRecipientsPage />} />
+          <Route path="/client/securities" element={<ClientSecuritiesPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,7 +49,9 @@ import EmployeeLoansPage from './pages/employee/EmployeeLoansPage'
 import ActuaryManagementPage from './pages/employee/ActuaryManagementPage'
 import StockExchangesPage from './pages/employee/StockExchangesPage'
 import SecuritiesPage from './pages/securities/SecuritiesPage'
+import ListingDetailPage from './pages/securities/ListingDetailPage'
 import ClientSecuritiesPage from './pages/client/ClientSecuritiesPage'
+import ClientListingDetailPage from './pages/client/ClientListingDetailPage'
 import NotFoundPage from './pages/NotFoundPage'
 
 function App() {
@@ -85,6 +87,7 @@ function App() {
               <Route path="/admin/actuaries" element={<ActuaryManagementPage />} />
               <Route path="/admin/stock-exchanges" element={<StockExchangesPage />} />
               <Route path="/securities" element={<SecuritiesPage />} />
+              <Route path="/securities/:id" element={<ListingDetailPage />} />
             </Route>
           </Route>
 
@@ -114,6 +117,7 @@ function App() {
           <Route path="/client/loans/:id" element={<ClientLoanDetailPage />} />
           <Route path="/client/recipients" element={<ClientRecipientsPage />} />
           <Route path="/client/securities" element={<ClientSecuritiesPage />} />
+          <Route path="/client/securities/:id" element={<ClientListingDetailPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -63,6 +63,9 @@ function Navbar() {
             {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
               <NavLink to="/admin/stock-exchanges" className={linkClass}>Stock Exchanges</NavLink>
             )}
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
+              <NavLink to="/securities" className={linkClass}>Securities</NavLink>
+            )}
           </div>
 
           {/* Desktop CTA */}
@@ -142,6 +145,9 @@ function Navbar() {
             )}
             {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
               <NavLink to="/admin/stock-exchanges" className={linkClass} onClick={() => setMenuOpen(false)}>Stock Exchanges</NavLink>
+            )}
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
+              <NavLink to="/securities" className={linkClass} onClick={() => setMenuOpen(false)}>Securities</NavLink>
             )}
             <div className="flex items-center gap-4">
               <button

--- a/src/layouts/ClientPortalLayout.jsx
+++ b/src/layouts/ClientPortalLayout.jsx
@@ -12,6 +12,7 @@ export const NAV_ITEMS = [
   { label: 'Exchange',  href: '/client/exchange',  icon: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15' },
   { label: 'Cards',     href: '/client/cards',     icon: 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z' },
   { label: 'Loans',     href: '/client/loans',     icon: 'M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z' },
+  { label: 'Securities', href: '/client/securities', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z' },
 ]
 
 export default function ClientPortalLayout({ children }) {

--- a/src/pages/client/ClientListingDetailPage.jsx
+++ b/src/pages/client/ClientListingDetailPage.jsx
@@ -1,0 +1,309 @@
+import { useEffect, useRef, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import {
+  ResponsiveContainer, LineChart, Line,
+  XAxis, YAxis, Tooltip, CartesianGrid,
+} from 'recharts'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { clientSecuritiesService } from '../../services/clientSecuritiesService'
+import { fmt } from '../../utils/formatting'
+
+const PERIODS = [
+  { label: 'Day',     days: 1    },
+  { label: 'Week',    days: 7    },
+  { label: 'Month',   days: 30   },
+  { label: 'Year',    days: 365  },
+  { label: '5 Years', days: 1825 },
+  { label: 'All',     days: null },
+]
+
+function InfoRow({ label, children }) {
+  return (
+    <tr className="border-b border-slate-100 dark:border-slate-800 last:border-0">
+      <td className="px-5 py-3 text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium w-48 whitespace-nowrap">{label}</td>
+      <td className="px-5 py-3 text-slate-900 dark:text-white">{children}</td>
+    </tr>
+  )
+}
+
+export default function ClientListingDetailPage() {
+  const { id } = useParams()
+  const [listing, setListing]               = useState(null)
+  const [detail, setDetail]                 = useState(null)
+  const [history, setHistory]               = useState([])
+  const [period, setPeriod]                 = useState(PERIODS[2])
+  const [loading, setLoading]               = useState(true)
+  const [historyLoading, setHistoryLoading] = useState(false)
+  const [error, setError]                   = useState(null)
+  const skipInitialPeriod                   = useRef(true)
+
+  useWindowTitle(listing ? `${listing.ticker} | AnkaBanka` : 'Securities | AnkaBanka')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    clientSecuritiesService.getListing(id)
+      .then(result => {
+        if (cancelled) return
+        setListing(result.listing)
+        setDetail(result.detail)
+        setHistory(result.priceHistory)
+      })
+      .catch(() => { if (!cancelled) setError(true) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [id])
+
+  useEffect(() => {
+    if (skipInitialPeriod.current) {
+      skipInitialPeriod.current = false
+      return
+    }
+    const to = new Date()
+    const from = period.days
+      ? new Date(to.getTime() - period.days * 86_400_000)
+      : new Date('1970-01-01')
+    setHistoryLoading(true)
+    clientSecuritiesService
+      .getListingHistory(id, from.toISOString().slice(0, 10), to.toISOString().slice(0, 10))
+      .then(data => setHistory(Array.isArray(data) ? data : []))
+      .catch(() => {})
+      .finally(() => setHistoryLoading(false))
+  }, [period]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (loading) {
+    return (
+      <ClientPortalLayout>
+        <div className="flex items-center justify-center py-32">
+          <p className="text-slate-500 dark:text-slate-400 text-sm">Loading…</p>
+        </div>
+      </ClientPortalLayout>
+    )
+  }
+
+  if (error || !listing) {
+    return (
+      <ClientPortalLayout>
+        <div className="flex items-center justify-center py-32">
+          <p className="text-red-500 text-sm">Failed to load listing.</p>
+        </div>
+      </ClientPortalLayout>
+    )
+  }
+
+  const sortedHistory = [...history].sort((a, b) => (a.date < b.date ? 1 : -1))
+
+  return (
+    <ClientPortalLayout>
+      <div className="p-6 max-w-4xl">
+
+        {/* Header */}
+        <div className="flex items-start justify-between mb-5">
+          <div>
+            <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white">
+              {listing.ticker}
+            </h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">{listing.name}</p>
+          </div>
+          <Link to="/client/securities" className="text-sm text-violet-600 dark:text-violet-400 hover:underline mt-1">
+            ← Back
+          </Link>
+        </div>
+
+        {/* Price chart */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 mb-5">
+          <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-4">Price Chart</p>
+          {history.length === 0 ? (
+            <div className="flex items-center justify-center min-h-[180px]">
+              <p className="text-slate-400 dark:text-slate-500 text-sm">No data available.</p>
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height={220}>
+              <LineChart
+                data={[...history]
+                  .sort((a, b) => (a.date < b.date ? -1 : 1))
+                  .map(r => ({ date: String(r.date).slice(0, 10), price: r.price ?? 0 }))}
+                margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 11, fill: '#94a3b8' }}
+                  tickLine={false}
+                  axisLine={false}
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  tick={{ fontSize: 11, fill: '#94a3b8' }}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={v => fmt(v)}
+                  width={80}
+                />
+                <Tooltip
+                  formatter={(v) => [fmt(v), 'Price']}
+                  contentStyle={{
+                    fontSize: 12,
+                    border: '1px solid #e2e8f0',
+                    borderRadius: 8,
+                    background: '#fff',
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="price"
+                  stroke="#7c3aed"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        {/* Period selector */}
+        <div className="flex gap-1 flex-wrap mb-5">
+          {PERIODS.map(p => (
+            <button
+              key={p.label}
+              onClick={() => setPeriod(p)}
+              className={`px-3 py-1.5 text-xs tracking-widest uppercase font-medium rounded transition-colors ${
+                period.label === p.label
+                  ? 'bg-violet-600 text-white'
+                  : 'bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:border-violet-400 dark:hover:border-violet-500'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Base info */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl mb-5 overflow-hidden">
+          <div className="px-5 py-3 border-b border-slate-100 dark:border-slate-800">
+            <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Overview</p>
+          </div>
+          <table className="w-full text-sm">
+            <tbody>
+              <InfoRow label="Ticker">{listing.ticker}</InfoRow>
+              <InfoRow label="Name">{listing.name}</InfoRow>
+              <InfoRow label="Exchange">{listing.exchangeAcronym || '—'}</InfoRow>
+              <InfoRow label="Price">{fmt(listing.price)}</InfoRow>
+              <InfoRow label="Ask">{fmt(listing.ask)}</InfoRow>
+              <InfoRow label="Bid">{fmt(listing.bid)}</InfoRow>
+              <InfoRow label="Change">
+                <span className={listing.changePercent >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500 dark:text-red-400'}>
+                  {listing.changePercent >= 0 ? '+' : ''}{listing.changePercent.toFixed(2)}%
+                </span>
+              </InfoRow>
+              <InfoRow label="Volume">{fmt(listing.volume)}</InfoRow>
+              <InfoRow label="Initial Margin Cost">{fmt(listing.initialMarginCost)}</InfoRow>
+            </tbody>
+          </table>
+        </div>
+
+        {/* Stock-specific */}
+        {detail?.type === 'STOCK' && (
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl mb-5 overflow-hidden">
+            <div className="px-5 py-3 border-b border-slate-100 dark:border-slate-800">
+              <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Stock Details</p>
+            </div>
+            <table className="w-full text-sm">
+              <tbody>
+                <InfoRow label="Outstanding Shares">
+                  {detail.outstandingShares ? detail.outstandingShares.toLocaleString() : '—'}
+                </InfoRow>
+                <InfoRow label="Dividend Yield">
+                  {detail.dividendYield ? `${(detail.dividendYield * 100).toFixed(2)}%` : '—'}
+                </InfoRow>
+              </tbody>
+            </table>
+            <div className="px-5 py-3 border-t border-slate-100 dark:border-slate-800">
+              <Link
+                to={`/client/securities/${id}/options`}
+                className="text-sm text-violet-600 dark:text-violet-400 hover:underline"
+              >
+                View Options →
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {/* Futures-specific */}
+        {detail?.type === 'FUTURES_CONTRACT' && (
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl mb-5 overflow-hidden">
+            <div className="px-5 py-3 border-b border-slate-100 dark:border-slate-800">
+              <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Futures Details</p>
+            </div>
+            <table className="w-full text-sm">
+              <tbody>
+                <InfoRow label="Contract Size">{detail.contractSize?.toLocaleString() ?? '—'}</InfoRow>
+                <InfoRow label="Contract Unit">{detail.contractUnit}</InfoRow>
+                <InfoRow label="Settlement Date">{detail.settlementDate}</InfoRow>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Price history table */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+          <div className="px-5 py-3 border-b border-slate-100 dark:border-slate-800 flex items-center justify-between">
+            <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Price History</p>
+            {historyLoading && <p className="text-xs text-slate-400 dark:text-slate-500">Loading…</p>}
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 dark:border-slate-700">
+                  {['Date', 'Close', 'High (Ask)', 'Low (Bid)', 'Change', 'Volume'].map(h => (
+                    <th key={h} className="px-4 py-3 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {sortedHistory.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-10 text-center text-slate-400 dark:text-slate-500 text-sm">
+                      No history available.
+                    </td>
+                  </tr>
+                ) : (
+                  sortedHistory.map((row, i) => (
+                    <tr
+                      key={i}
+                      className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                        i % 2 !== 0 ? 'bg-slate-50/50 dark:bg-slate-800/20' : ''
+                      }`}
+                    >
+                      <td className="px-4 py-2.5 text-slate-700 dark:text-slate-300 font-mono">{String(row.date).slice(0, 10)}</td>
+                      <td className="px-4 py-2.5 text-slate-700 dark:text-slate-300">{fmt(row.price ?? 0)}</td>
+                      <td className="px-4 py-2.5 text-slate-700 dark:text-slate-300">{fmt(row.ask ?? 0)}</td>
+                      <td className="px-4 py-2.5 text-slate-700 dark:text-slate-300">{fmt(row.bid ?? 0)}</td>
+                      <td className={`px-4 py-2.5 font-medium tabular-nums ${
+                        (row.change ?? 0) >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500 dark:text-red-400'
+                      }`}>
+                        {(row.change ?? 0) >= 0 ? '+' : ''}{fmt(row.change ?? 0)}
+                      </td>
+                      <td className="px-4 py-2.5 text-slate-700 dark:text-slate-300">{fmt(row.volume ?? 0)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          {sortedHistory.length > 0 && (
+            <div className="px-4 py-2.5 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+              {sortedHistory.length} row{sortedHistory.length !== 1 ? 's' : ''}
+            </div>
+          )}
+        </div>
+
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/client/ClientSecuritiesPage.jsx
+++ b/src/pages/client/ClientSecuritiesPage.jsx
@@ -1,0 +1,359 @@
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { clientSecuritiesService } from '../../services/clientSecuritiesService'
+import { fmt } from '../../utils/formatting'
+
+const TABS = [
+  { label: 'Stocks',  type: 'STOCK' },
+  { label: 'Futures', type: 'FUTURES_CONTRACT' },
+]
+
+const SORT_COLS = [
+  { key: 'price',              label: 'Price' },
+  { key: 'volume',             label: 'Volume' },
+  { key: 'maintenance_margin', label: 'Initial Margin Cost' },
+]
+
+const REFRESH_INTERVAL = 60_000
+
+function FilterInput({ label, value, onChange, type = 'text', placeholder }) {
+  return (
+    <div>
+      <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="input-field w-full text-sm"
+      />
+    </div>
+  )
+}
+
+function RangeFilter({ label, min, max, onMin, onMax }) {
+  return (
+    <div>
+      <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">{label}</label>
+      <div className="flex gap-1">
+        <input type="number" value={min} onChange={e => onMin(e.target.value)} placeholder="Min"
+          className="input-field w-full text-sm" />
+        <input type="number" value={max} onChange={e => onMax(e.target.value)} placeholder="Max"
+          className="input-field w-full text-sm" />
+      </div>
+    </div>
+  )
+}
+
+export default function ClientSecuritiesPage() {
+  useWindowTitle('Securities | AnkaBanka')
+  const navigate = useNavigate()
+
+  const [activeTab, setActiveTab] = useState(TABS[0])
+  const [listings, setListings]   = useState([])
+  const [loading, setLoading]     = useState(true)
+  const [error, setError]         = useState(null)
+  const [refreshingId, setRefreshingId] = useState(null)
+
+  // Sort
+  const [sortBy, setSortBy]       = useState(null)
+  const [sortOrder, setSortOrder] = useState('ASC')
+
+  // Search
+  const [searchQuery, setSearchQuery]         = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const searchTimer = useRef(null)
+
+  // Filters
+  const [filters, setFilters] = useState({
+    exchange: '',
+    priceMin: '', priceMax: '',
+    askMin: '',   askMax: '',
+    bidMin: '',   bidMax: '',
+    volumeMin: '', volumeMax: '',
+    settlementMin: '', settlementMax: '',
+  })
+
+  function setFilter(key, val) {
+    setFilters(prev => ({ ...prev, [key]: val }))
+  }
+
+  // Debounce search
+  useEffect(() => {
+    if (searchTimer.current) clearTimeout(searchTimer.current)
+    searchTimer.current = setTimeout(() => setDebouncedSearch(searchQuery), 400)
+    return () => clearTimeout(searchTimer.current)
+  }, [searchQuery])
+
+  // Load listings
+  const loadListings = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await clientSecuritiesService.getListings({
+        type: activeTab.type,
+        ...(sortBy ? { sortBy, sortOrder } : {}),
+      })
+      setListings(result.items ?? [])
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [activeTab, sortBy, sortOrder])
+
+  useEffect(() => { loadListings() }, [loadListings])
+
+  // Auto-refresh
+  useEffect(() => {
+    const timer = setInterval(loadListings, REFRESH_INTERVAL)
+    return () => clearInterval(timer)
+  }, [loadListings])
+
+  // Per-row refresh
+  async function handleRefreshRow(listing) {
+    setRefreshingId(listing.id)
+    try {
+      const updated = await clientSecuritiesService.getListingById(listing.id)
+      setListings(prev => prev.map(l => l.id === updated.id ? updated : l))
+    } finally {
+      setRefreshingId(null)
+    }
+  }
+
+  // Sort column click
+  function handleSort(key) {
+    if (sortBy === key) {
+      setSortOrder(o => o === 'ASC' ? 'DESC' : 'ASC')
+    } else {
+      setSortBy(key)
+      setSortOrder('ASC')
+    }
+  }
+
+  // Client-side filtering
+  const filtered = listings.filter(l => {
+    if (debouncedSearch) {
+      const q = debouncedSearch.toLowerCase()
+      if (!l.ticker.toLowerCase().includes(q) && !l.name.toLowerCase().includes(q)) return false
+    }
+    if (filters.exchange  && !l.exchangeAcronym.toLowerCase().startsWith(filters.exchange.toLowerCase())) return false
+    if (filters.priceMin  !== '' && l.price  < Number(filters.priceMin))  return false
+    if (filters.priceMax  !== '' && l.price  > Number(filters.priceMax))  return false
+    if (filters.askMin    !== '' && l.ask    < Number(filters.askMin))    return false
+    if (filters.askMax    !== '' && l.ask    > Number(filters.askMax))    return false
+    if (filters.bidMin    !== '' && l.bid    < Number(filters.bidMin))    return false
+    if (filters.bidMax    !== '' && l.bid    > Number(filters.bidMax))    return false
+    if (filters.volumeMin !== '' && l.volume < Number(filters.volumeMin)) return false
+    if (filters.volumeMax !== '' && l.volume > Number(filters.volumeMax)) return false
+    if (activeTab.type === 'FUTURES_CONTRACT') {
+      const sd = l.futuresDetail?.settlementDate
+      if (filters.settlementMin && sd && sd < filters.settlementMin) return false
+      if (filters.settlementMax && sd && sd > filters.settlementMax) return false
+    }
+    return true
+  })
+
+  function SortIcon({ col }) {
+    if (sortBy !== col) return <span className="text-slate-300 dark:text-slate-600 ml-1">↕</span>
+    return <span className="text-violet-500 ml-1">{sortOrder === 'ASC' ? '↑' : '↓'}</span>
+  }
+
+  return (
+    <ClientPortalLayout>
+      <div className="p-6">
+
+        {/* Header */}
+        <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white mb-1">Securities</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">Browse available listings</p>
+
+        {/* Search */}
+        <div className="mb-5">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder="Search by ticker or name…"
+            className="input-field w-full max-w-sm text-sm"
+          />
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 mb-5 border-b border-slate-200 dark:border-slate-700">
+          {TABS.map(tab => (
+            <button
+              key={tab.type}
+              onClick={() => { setActiveTab(tab); setSortBy(null) }}
+              className={`px-5 py-2.5 text-xs tracking-widest uppercase font-medium transition-colors border-b-2 -mb-px ${
+                activeTab.type === tab.type
+                  ? 'border-violet-500 text-violet-600 dark:text-violet-400'
+                  : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Two-column layout */}
+        <div className="flex gap-5 items-start">
+
+          {/* Left: Filters */}
+          <aside className="w-52 shrink-0 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4 shadow-sm flex flex-col gap-3">
+            <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Filters</p>
+
+            <FilterInput
+              label="Exchange"
+              value={filters.exchange}
+              onChange={v => setFilter('exchange', v)}
+              placeholder="Prefix…"
+            />
+            <RangeFilter
+              label="Price"
+              min={filters.priceMin} max={filters.priceMax}
+              onMin={v => setFilter('priceMin', v)} onMax={v => setFilter('priceMax', v)}
+            />
+            <RangeFilter
+              label="Ask"
+              min={filters.askMin} max={filters.askMax}
+              onMin={v => setFilter('askMin', v)} onMax={v => setFilter('askMax', v)}
+            />
+            <RangeFilter
+              label="Bid"
+              min={filters.bidMin} max={filters.bidMax}
+              onMin={v => setFilter('bidMin', v)} onMax={v => setFilter('bidMax', v)}
+            />
+            <RangeFilter
+              label="Volume"
+              min={filters.volumeMin} max={filters.volumeMax}
+              onMin={v => setFilter('volumeMin', v)} onMax={v => setFilter('volumeMax', v)}
+            />
+
+            {activeTab.type === 'FUTURES_CONTRACT' && (
+              <>
+                <div className="border-t border-slate-100 dark:border-slate-800" />
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Settlement Date</label>
+                  <div className="flex flex-col gap-1">
+                    <input type="date" value={filters.settlementMin}
+                      onChange={e => setFilter('settlementMin', e.target.value)}
+                      className="input-field w-full text-sm" />
+                    <input type="date" value={filters.settlementMax}
+                      onChange={e => setFilter('settlementMax', e.target.value)}
+                      className="input-field w-full text-sm" />
+                  </div>
+                </div>
+              </>
+            )}
+
+            <button
+              onClick={() => setFilters({ exchange: '', priceMin: '', priceMax: '', askMin: '', askMax: '', bidMin: '', bidMax: '', volumeMin: '', volumeMax: '', settlementMin: '', settlementMax: '' })}
+              className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors text-left"
+            >
+              Clear filters
+            </button>
+          </aside>
+
+          {/* Right: Table */}
+          <div className="flex-1 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+            {loading ? (
+              <div className="flex items-center justify-center py-20">
+                <p className="text-slate-500 dark:text-slate-400 text-sm">Loading {activeTab.label.toLowerCase()}…</p>
+              </div>
+            ) : error ? (
+              <div className="flex items-center justify-center py-20">
+                <p className="text-red-500 text-sm">Failed to load listings.</p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-200 dark:border-slate-700">
+                      {['Ticker', 'Name'].map(h => (
+                        <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                          {h}
+                        </th>
+                      ))}
+                      {SORT_COLS.map(col => (
+                        <th
+                          key={col.key}
+                          onClick={() => handleSort(col.key)}
+                          className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap cursor-pointer select-none hover:text-slate-900 dark:hover:text-white transition-colors"
+                        >
+                          {col.label}<SortIcon col={col.key} />
+                        </th>
+                      ))}
+                      <th className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                        Change
+                      </th>
+                      <th className="px-4 py-4" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                          No listings found.
+                        </td>
+                      </tr>
+                    ) : (
+                      filtered.map((l, i) => (
+                        <tr
+                          key={l.id}
+                          className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                            i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
+                          }`}
+                        >
+                          <td className="px-4 py-3 font-mono text-slate-900 dark:text-white font-medium">{l.ticker}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{l.name}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.price)}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.volume)}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.initialMarginCost)}</td>
+                          <td className={`px-4 py-3 font-medium tabular-nums ${
+                            l.changePercent >= 0
+                              ? 'text-emerald-600 dark:text-emerald-400'
+                              : 'text-red-500 dark:text-red-400'
+                          }`}>
+                            {l.changePercent >= 0 ? '+' : ''}{l.changePercent.toFixed(2)}%
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2 justify-end">
+                              <button
+                                onClick={() => navigate(`/client/securities/${l.id}/order`)}
+                                className="btn-primary text-xs px-3 py-1"
+                              >
+                                Buy
+                              </button>
+                              <button
+                                onClick={() => handleRefreshRow(l)}
+                                disabled={refreshingId === l.id}
+                                title="Refresh"
+                                className="p-1.5 text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 disabled:opacity-40 transition-colors"
+                              >
+                                <svg className={`w-4 h-4 ${refreshingId === l.id ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                                </svg>
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {!loading && !error && filtered.length > 0 && (
+              <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+                {filtered.length} listing{filtered.length !== 1 ? 's' : ''}
+              </div>
+            )}
+          </div>
+
+        </div>
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/client/ClientSecuritiesPage.jsx
+++ b/src/pages/client/ClientSecuritiesPage.jsx
@@ -116,7 +116,8 @@ export default function ClientSecuritiesPage() {
   async function handleRefreshRow(listing) {
     setRefreshingId(listing.id)
     try {
-      const updated = await clientSecuritiesService.getListingById(listing.id)
+      const result = await clientSecuritiesService.getListing(listing.id)
+      const updated = result.listing
       setListings(prev => prev.map(l => l.id === updated.id ? updated : l))
     } finally {
       setRefreshingId(null)
@@ -306,7 +307,14 @@ export default function ClientSecuritiesPage() {
                             i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
                           }`}
                         >
-                          <td className="px-4 py-3 font-mono text-slate-900 dark:text-white font-medium">{l.ticker}</td>
+                          <td className="px-4 py-3 font-mono font-medium">
+                            <button
+                              onClick={() => navigate(`/client/securities/${l.id}`)}
+                              className="text-violet-600 dark:text-violet-400 hover:underline"
+                            >
+                              {l.ticker}
+                            </button>
+                          </td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{l.name}</td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.price)}</td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.volume)}</td>

--- a/src/pages/securities/ListingDetailPage.jsx
+++ b/src/pages/securities/ListingDetailPage.jsx
@@ -1,0 +1,332 @@
+import { useEffect, useRef, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import {
+  ResponsiveContainer, LineChart, Line,
+  XAxis, YAxis, Tooltip, CartesianGrid,
+} from 'recharts'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { securitiesService } from '../../services/securitiesService'
+import { fmt } from '../../utils/formatting'
+
+const PERIODS = [
+  { label: 'Day',     days: 1    },
+  { label: 'Week',    days: 7    },
+  { label: 'Month',   days: 30   },
+  { label: 'Year',    days: 365  },
+  { label: '5 Years', days: 1825 },
+  { label: 'All',     days: null },
+]
+
+function InfoRow({ label, children }) {
+  return (
+    <tr className="border-b border-slate-100 dark:border-slate-800 last:border-0">
+      <td className="px-6 py-3 text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium w-52 whitespace-nowrap">{label}</td>
+      <td className="px-6 py-3 text-slate-900 dark:text-white">{children}</td>
+    </tr>
+  )
+}
+
+export default function ListingDetailPage() {
+  const { id } = useParams()
+  const [listing, setListing]         = useState(null)
+  const [detail, setDetail]           = useState(null)
+  const [history, setHistory]         = useState([])
+  const [period, setPeriod]           = useState(PERIODS[2]) // Month default
+  const [loading, setLoading]         = useState(true)
+  const [historyLoading, setHistoryLoading] = useState(false)
+  const [error, setError]             = useState(null)
+  const skipInitialPeriod             = useRef(true)
+
+  useWindowTitle(listing ? `${listing.ticker} | AnkaBanka` : 'Securities | AnkaBanka')
+
+  // Initial load: listing detail + embedded 30-day history
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    securitiesService.getListing(id)
+      .then(result => {
+        if (cancelled) return
+        setListing(result.listing)
+        setDetail(result.detail)
+        setHistory(result.priceHistory)
+      })
+      .catch(() => { if (!cancelled) setError(true) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [id])
+
+  // Reload history when period selector changes (skip on initial render)
+  useEffect(() => {
+    if (skipInitialPeriod.current) {
+      skipInitialPeriod.current = false
+      return
+    }
+    const to = new Date()
+    const from = period.days
+      ? new Date(to.getTime() - period.days * 86_400_000)
+      : new Date('1970-01-01')
+    setHistoryLoading(true)
+    securitiesService
+      .getListingHistory(id, from.toISOString().slice(0, 10), to.toISOString().slice(0, 10))
+      .then(data => setHistory(Array.isArray(data) ? data : []))
+      .catch(() => {})
+      .finally(() => setHistoryLoading(false))
+  }, [period]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
+        <p className="text-slate-500 dark:text-slate-400 text-sm">Loading…</p>
+      </div>
+    )
+  }
+
+  if (error || !listing) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
+        <p className="text-red-500 text-sm">Failed to load listing.</p>
+      </div>
+    )
+  }
+
+  const sortedHistory = [...history].sort((a, b) => (a.date < b.date ? 1 : -1))
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-5xl mx-auto">
+
+        {/* Header */}
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <div className="flex items-start justify-between mb-3">
+          <div>
+            <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white">
+              {listing.ticker}
+            </h1>
+            <p className="text-slate-500 dark:text-slate-400 text-sm mt-1">{listing.name}</p>
+          </div>
+          <Link to="/securities" className="text-sm text-violet-600 dark:text-violet-400 hover:underline mt-2">
+            ← Back to Securities
+          </Link>
+        </div>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+
+        {/* Price chart */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 mb-6">
+          <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-4">Price Chart</p>
+          {history.length === 0 ? (
+            <div className="flex items-center justify-center min-h-[200px]">
+              <p className="text-slate-400 dark:text-slate-500 text-sm">No data available.</p>
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height={240}>
+              <LineChart
+                data={[...history]
+                  .sort((a, b) => (a.date < b.date ? -1 : 1))
+                  .map(r => ({ date: String(r.date).slice(0, 10), price: r.price ?? 0 }))}
+                margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 11, fill: '#94a3b8' }}
+                  tickLine={false}
+                  axisLine={false}
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  tick={{ fontSize: 11, fill: '#94a3b8' }}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={v => fmt(v)}
+                  width={80}
+                />
+                <Tooltip
+                  formatter={(v) => [fmt(v), 'Price']}
+                  contentStyle={{
+                    fontSize: 12,
+                    border: '1px solid #e2e8f0',
+                    borderRadius: 8,
+                    background: '#fff',
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="price"
+                  stroke="#7c3aed"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        {/* Period selector */}
+        <div className="flex gap-1 flex-wrap mb-8">
+          {PERIODS.map(p => (
+            <button
+              key={p.label}
+              onClick={() => setPeriod(p)}
+              className={`px-4 py-2 text-xs tracking-widest uppercase font-medium rounded transition-colors ${
+                period.label === p.label
+                  ? 'bg-violet-600 text-white'
+                  : 'bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:border-violet-400 dark:hover:border-violet-500'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Base info table */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl mb-6 overflow-hidden">
+          <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800">
+            <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Overview</p>
+          </div>
+          <table className="w-full text-sm">
+            <tbody>
+              <InfoRow label="Ticker">{listing.ticker}</InfoRow>
+              <InfoRow label="Name">{listing.name}</InfoRow>
+              <InfoRow label="Exchange">{listing.exchangeAcronym || '—'}</InfoRow>
+              <InfoRow label="Price">{fmt(listing.price)}</InfoRow>
+              <InfoRow label="Ask">{fmt(listing.ask)}</InfoRow>
+              <InfoRow label="Bid">{fmt(listing.bid)}</InfoRow>
+              <InfoRow label="Change">
+                <span className={listing.changePercent >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500 dark:text-red-400'}>
+                  {listing.changePercent >= 0 ? '+' : ''}{listing.changePercent.toFixed(2)}%
+                </span>
+              </InfoRow>
+              <InfoRow label="Volume">{fmt(listing.volume)}</InfoRow>
+              <InfoRow label="Initial Margin Cost">{fmt(listing.initialMarginCost)}</InfoRow>
+            </tbody>
+          </table>
+        </div>
+
+        {/* Stock-specific section */}
+        {detail?.type === 'STOCK' && (
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl mb-6 overflow-hidden">
+            <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800">
+              <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Stock Details</p>
+            </div>
+            <table className="w-full text-sm">
+              <tbody>
+                <InfoRow label="Outstanding Shares">
+                  {detail.outstandingShares ? detail.outstandingShares.toLocaleString() : '—'}
+                </InfoRow>
+                <InfoRow label="Dividend Yield">
+                  {detail.dividendYield ? `${(detail.dividendYield * 100).toFixed(2)}%` : '—'}
+                </InfoRow>
+              </tbody>
+            </table>
+            <div className="px-6 py-4 border-t border-slate-100 dark:border-slate-800">
+              <Link
+                to={`/securities/${id}/options`}
+                className="text-sm text-violet-600 dark:text-violet-400 hover:underline"
+              >
+                View Options →
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {/* Forex-specific section */}
+        {detail?.type === 'FOREX_PAIR' && (
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl mb-6 overflow-hidden">
+            <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800">
+              <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Forex Details</p>
+            </div>
+            <table className="w-full text-sm">
+              <tbody>
+                <InfoRow label="Base Currency">{detail.baseCurrency}</InfoRow>
+                <InfoRow label="Quote Currency">{detail.quoteCurrency}</InfoRow>
+                <InfoRow label="Liquidity">{detail.liquidity}</InfoRow>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Futures-specific section */}
+        {detail?.type === 'FUTURES_CONTRACT' && (
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl mb-6 overflow-hidden">
+            <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800">
+              <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Futures Details</p>
+            </div>
+            <table className="w-full text-sm">
+              <tbody>
+                <InfoRow label="Contract Size">{detail.contractSize?.toLocaleString() ?? '—'}</InfoRow>
+                <InfoRow label="Contract Unit">{detail.contractUnit}</InfoRow>
+                <InfoRow label="Settlement Date">{detail.settlementDate}</InfoRow>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Daily price history table */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+          <div className="px-6 py-4 border-b border-slate-100 dark:border-slate-800 flex items-center justify-between">
+            <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Price History</p>
+            {historyLoading && (
+              <p className="text-xs text-slate-400 dark:text-slate-500">Loading…</p>
+            )}
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 dark:border-slate-700">
+                  {['Date', 'Close', 'High (Ask)', 'Low (Bid)', 'Change', 'Volume'].map(h => (
+                    <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {sortedHistory.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                      No history available.
+                    </td>
+                  </tr>
+                ) : (
+                  sortedHistory.map((row, i) => (
+                    <tr
+                      key={i}
+                      className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                        i % 2 !== 0 ? 'bg-slate-50/50 dark:bg-slate-800/20' : ''
+                      }`}
+                    >
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300 font-mono">
+                        {String(row.date).slice(0, 10)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(row.price ?? 0)}</td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(row.ask ?? 0)}</td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(row.bid ?? 0)}</td>
+                      <td className={`px-4 py-3 font-medium tabular-nums ${
+                        (row.change ?? 0) >= 0
+                          ? 'text-emerald-600 dark:text-emerald-400'
+                          : 'text-red-500 dark:text-red-400'
+                      }`}>
+                        {(row.change ?? 0) >= 0 ? '+' : ''}{fmt(row.change ?? 0)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">
+                        {fmt(row.volume ?? 0)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          {sortedHistory.length > 0 && (
+            <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+              {sortedHistory.length} row{sortedHistory.length !== 1 ? 's' : ''}
+            </div>
+          )}
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/pages/securities/SecuritiesPage.jsx
+++ b/src/pages/securities/SecuritiesPage.jsx
@@ -1,0 +1,362 @@
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { useAuth } from '../../context/AuthContext'
+import { securitiesService } from '../../services/securitiesService'
+import { fmt } from '../../utils/formatting'
+
+const TABS = [
+  { label: 'Stocks',      type: 'STOCK' },
+  { label: 'Futures',     type: 'FUTURES_CONTRACT' },
+  { label: 'Forex Pairs', type: 'FOREX_PAIR' },
+]
+
+const SORT_COLS = [
+  { key: 'price',              label: 'Price' },
+  { key: 'volume',             label: 'Volume' },
+  { key: 'maintenance_margin', label: 'Initial Margin Cost' },
+]
+
+const REFRESH_INTERVAL = 60_000
+
+function FilterInput({ label, value, onChange, type = 'text', placeholder }) {
+  return (
+    <div>
+      <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="input-field w-full text-sm"
+      />
+    </div>
+  )
+}
+
+function RangeFilter({ label, min, max, onMin, onMax }) {
+  return (
+    <div>
+      <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">{label}</label>
+      <div className="flex gap-1">
+        <input type="number" value={min} onChange={e => onMin(e.target.value)} placeholder="Min"
+          className="input-field w-full text-sm" />
+        <input type="number" value={max} onChange={e => onMax(e.target.value)} placeholder="Max"
+          className="input-field w-full text-sm" />
+      </div>
+    </div>
+  )
+}
+
+export default function SecuritiesPage() {
+  useWindowTitle('Securities | AnkaBanka')
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  const [activeTab, setActiveTab] = useState(TABS[0])
+  const [listings, setListings]   = useState([])
+  const [loading, setLoading]     = useState(true)
+  const [error, setError]         = useState(null)
+  const [refreshingId, setRefreshingId] = useState(null)
+
+  // Sort
+  const [sortBy, setSortBy]       = useState(null)
+  const [sortOrder, setSortOrder] = useState('ASC')
+
+  // Search
+  const [searchQuery, setSearchQuery]       = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const searchTimer = useRef(null)
+
+  // Filters
+  const [filters, setFilters] = useState({
+    exchange: '',
+    priceMin: '', priceMax: '',
+    askMin: '',   askMax: '',
+    bidMin: '',   bidMax: '',
+    volumeMin: '', volumeMax: '',
+    settlementMin: '', settlementMax: '',
+  })
+
+  function setFilter(key, val) {
+    setFilters(prev => ({ ...prev, [key]: val }))
+  }
+
+  // Debounce search
+  useEffect(() => {
+    if (searchTimer.current) clearTimeout(searchTimer.current)
+    searchTimer.current = setTimeout(() => setDebouncedSearch(searchQuery), 400)
+    return () => clearTimeout(searchTimer.current)
+  }, [searchQuery])
+
+  // Load listings
+  const loadListings = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await securitiesService.getListings({
+        type: activeTab.type,
+        ...(sortBy ? { sortBy, sortOrder } : {}),
+      })
+      setListings(result.items ?? [])
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [activeTab, sortBy, sortOrder])
+
+  useEffect(() => { loadListings() }, [loadListings])
+
+  // Auto-refresh
+  useEffect(() => {
+    const timer = setInterval(loadListings, REFRESH_INTERVAL)
+    return () => clearInterval(timer)
+  }, [loadListings])
+
+  // Per-row refresh
+  async function handleRefreshRow(listing) {
+    setRefreshingId(listing.id)
+    try {
+      const updated = await securitiesService.getListingById(listing.id)
+      setListings(prev => prev.map(l => l.id === updated.id ? updated : l))
+    } finally {
+      setRefreshingId(null)
+    }
+  }
+
+  // Sort column click
+  function handleSort(key) {
+    if (sortBy === key) {
+      setSortOrder(o => o === 'ASC' ? 'DESC' : 'ASC')
+    } else {
+      setSortBy(key)
+      setSortOrder('ASC')
+    }
+  }
+
+  // Client-side filtering
+  const filtered = listings.filter(l => {
+    if (debouncedSearch) {
+      const q = debouncedSearch.toLowerCase()
+      if (!l.ticker.toLowerCase().includes(q) && !l.name.toLowerCase().includes(q)) return false
+    }
+    if (filters.exchange && !l.exchangeAcronym.toLowerCase().startsWith(filters.exchange.toLowerCase())) return false
+    if (filters.priceMin  !== '' && l.price  < Number(filters.priceMin))  return false
+    if (filters.priceMax  !== '' && l.price  > Number(filters.priceMax))  return false
+    if (filters.askMin    !== '' && l.ask    < Number(filters.askMin))    return false
+    if (filters.askMax    !== '' && l.ask    > Number(filters.askMax))    return false
+    if (filters.bidMin    !== '' && l.bid    < Number(filters.bidMin))    return false
+    if (filters.bidMax    !== '' && l.bid    > Number(filters.bidMax))    return false
+    if (filters.volumeMin !== '' && l.volume < Number(filters.volumeMin)) return false
+    if (filters.volumeMax !== '' && l.volume > Number(filters.volumeMax)) return false
+    if (activeTab.type === 'FUTURES_CONTRACT') {
+      const sd = l.futuresDetail?.settlementDate
+      if (filters.settlementMin && sd && sd < filters.settlementMin) return false
+      if (filters.settlementMax && sd && sd > filters.settlementMax) return false
+    }
+    return true
+  })
+
+  function SortIcon({ col }) {
+    if (sortBy !== col) return <span className="text-slate-300 dark:text-slate-600 ml-1">↕</span>
+    return <span className="text-violet-500 ml-1">{sortOrder === 'ASC' ? '↑' : '↓'}</span>
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+
+        {/* Header */}
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Securities</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+
+        {/* Search */}
+        <div className="mb-6">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder="Search by ticker or name…"
+            className="input-field w-full max-w-sm text-sm"
+          />
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 mb-6 border-b border-slate-200 dark:border-slate-700">
+          {TABS.map(tab => (
+            <button
+              key={tab.type}
+              onClick={() => { setActiveTab(tab); setSortBy(null) }}
+              className={`px-5 py-2.5 text-xs tracking-widest uppercase font-medium transition-colors border-b-2 -mb-px ${
+                activeTab.type === tab.type
+                  ? 'border-violet-500 text-violet-600 dark:text-violet-400'
+                  : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Two-column layout */}
+        <div className="flex gap-6 items-start">
+
+          {/* Left: Filters */}
+          <aside className="w-56 shrink-0 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm flex flex-col gap-4">
+            <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium">Filters</p>
+
+            <FilterInput
+              label="Exchange"
+              value={filters.exchange}
+              onChange={v => setFilter('exchange', v)}
+              placeholder="Prefix…"
+            />
+            <RangeFilter
+              label="Price"
+              min={filters.priceMin} max={filters.priceMax}
+              onMin={v => setFilter('priceMin', v)} onMax={v => setFilter('priceMax', v)}
+            />
+            <RangeFilter
+              label="Ask"
+              min={filters.askMin} max={filters.askMax}
+              onMin={v => setFilter('askMin', v)} onMax={v => setFilter('askMax', v)}
+            />
+            <RangeFilter
+              label="Bid"
+              min={filters.bidMin} max={filters.bidMax}
+              onMin={v => setFilter('bidMin', v)} onMax={v => setFilter('bidMax', v)}
+            />
+            <RangeFilter
+              label="Volume"
+              min={filters.volumeMin} max={filters.volumeMax}
+              onMin={v => setFilter('volumeMin', v)} onMax={v => setFilter('volumeMax', v)}
+            />
+
+            {activeTab.type === 'FUTURES_CONTRACT' && (
+              <>
+                <div className="border-t border-slate-100 dark:border-slate-800" />
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Settlement Date</label>
+                  <div className="flex flex-col gap-1">
+                    <input type="date" value={filters.settlementMin}
+                      onChange={e => setFilter('settlementMin', e.target.value)}
+                      className="input-field w-full text-sm" />
+                    <input type="date" value={filters.settlementMax}
+                      onChange={e => setFilter('settlementMax', e.target.value)}
+                      className="input-field w-full text-sm" />
+                  </div>
+                </div>
+              </>
+            )}
+
+            <button
+              onClick={() => setFilters({ exchange: '', priceMin: '', priceMax: '', askMin: '', askMax: '', bidMin: '', bidMax: '', volumeMin: '', volumeMax: '', settlementMin: '', settlementMax: '' })}
+              className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors text-left"
+            >
+              Clear filters
+            </button>
+          </aside>
+
+          {/* Right: Table */}
+          <div className="flex-1 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+            {loading ? (
+              <div className="flex items-center justify-center py-20">
+                <p className="text-slate-500 dark:text-slate-400 text-sm">Loading {activeTab.label.toLowerCase()}…</p>
+              </div>
+            ) : error ? (
+              <div className="flex items-center justify-center py-20">
+                <p className="text-red-500 text-sm">Failed to load listings.</p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-200 dark:border-slate-700">
+                      {['Ticker', 'Name'].map(h => (
+                        <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                          {h}
+                        </th>
+                      ))}
+                      {SORT_COLS.map(col => (
+                        <th
+                          key={col.key}
+                          onClick={() => handleSort(col.key)}
+                          className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap cursor-pointer select-none hover:text-slate-900 dark:hover:text-white transition-colors"
+                        >
+                          {col.label}<SortIcon col={col.key} />
+                        </th>
+                      ))}
+                      <th className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                        Change
+                      </th>
+                      <th className="px-4 py-4" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                          No listings found.
+                        </td>
+                      </tr>
+                    ) : (
+                      filtered.map((l, i) => (
+                        <tr
+                          key={l.id}
+                          className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                            i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
+                          }`}
+                        >
+                          <td className="px-4 py-3 font-mono text-slate-900 dark:text-white font-medium">{l.ticker}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{l.name}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.price)}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.volume)}</td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.initialMarginCost)}</td>
+                          <td className={`px-4 py-3 font-medium tabular-nums ${
+                            l.changePercent >= 0
+                              ? 'text-emerald-600 dark:text-emerald-400'
+                              : 'text-red-500 dark:text-red-400'
+                          }`}>
+                            {l.changePercent >= 0 ? '+' : ''}{l.changePercent.toFixed(2)}%
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2 justify-end">
+                              <button
+                                onClick={() => navigate(`/securities/${l.id}/order`)}
+                                className="btn-primary text-xs px-3 py-1"
+                              >
+                                Buy
+                              </button>
+                              <button
+                                onClick={() => handleRefreshRow(l)}
+                                disabled={refreshingId === l.id}
+                                title="Refresh"
+                                className="p-1.5 text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 disabled:opacity-40 transition-colors"
+                              >
+                                <svg className={`w-4 h-4 ${refreshingId === l.id ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                                </svg>
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {!loading && !error && filtered.length > 0 && (
+              <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+                {filtered.length} listing{filtered.length !== 1 ? 's' : ''}
+              </div>
+            )}
+          </div>
+
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/securities/SecuritiesPage.jsx
+++ b/src/pages/securities/SecuritiesPage.jsx
@@ -118,7 +118,8 @@ export default function SecuritiesPage() {
   async function handleRefreshRow(listing) {
     setRefreshingId(listing.id)
     try {
-      const updated = await securitiesService.getListingById(listing.id)
+      const result = await securitiesService.getListing(listing.id)
+      const updated = result.listing
       setListings(prev => prev.map(l => l.id === updated.id ? updated : l))
     } finally {
       setRefreshingId(null)
@@ -309,7 +310,14 @@ export default function SecuritiesPage() {
                             i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
                           }`}
                         >
-                          <td className="px-4 py-3 font-mono text-slate-900 dark:text-white font-medium">{l.ticker}</td>
+                          <td className="px-4 py-3 font-mono font-medium">
+                            <button
+                              onClick={() => navigate(`/securities/${l.id}`)}
+                              className="text-violet-600 dark:text-violet-400 hover:underline"
+                            >
+                              {l.ticker}
+                            </button>
+                          </td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{l.name}</td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.price)}</td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{fmt(l.volume)}</td>

--- a/src/services/clientSecuritiesService.js
+++ b/src/services/clientSecuritiesService.js
@@ -1,0 +1,34 @@
+import { clientApiClient } from './clientApiClient'
+import { listingFromApi } from '../models/Listing'
+
+export const clientSecuritiesService = {
+  async getListings({ type, exchange, ticker, name, page, pageSize, sortBy, sortOrder } = {}) {
+    const params = {}
+    if (type)       params.type      = type
+    if (exchange)   params.exchange  = exchange
+    if (ticker)     params.ticker    = ticker
+    if (name)       params.name      = name
+    if (page        != null) params.page     = page
+    if (pageSize    != null) params.pageSize = pageSize
+    if (sortBy)     params.sortBy    = sortBy
+    if (sortOrder)  params.sortOrder = sortOrder
+    const { data } = await clientApiClient.get('/securities', { params })
+    return {
+      ...data,
+      items: (data.listings ?? data.items ?? data).map(listingFromApi),
+    }
+  },
+
+  async getListingById(id) {
+    const { data } = await clientApiClient.get(`/securities/${id}`)
+    return listingFromApi(data.summary ?? data)
+  },
+
+  async getStocks(opts = {}) {
+    return this.getListings({ ...opts, type: 'STOCK' })
+  },
+
+  async getFutures(opts = {}) {
+    return this.getListings({ ...opts, type: 'FUTURES_CONTRACT' })
+  },
+}

--- a/src/services/clientSecuritiesService.js
+++ b/src/services/clientSecuritiesService.js
@@ -19,9 +19,21 @@ export const clientSecuritiesService = {
     }
   },
 
-  async getListingById(id) {
+  async getListing(id) {
     const { data } = await clientApiClient.get(`/securities/${id}`)
-    return listingFromApi(data.summary ?? data)
+    return {
+      listing:      listingFromApi(data.summary ?? data),
+      detail:       data.detail ?? null,
+      priceHistory: data.priceHistory ?? [],
+    }
+  },
+
+  async getListingHistory(id, from, to) {
+    const params = {}
+    if (from) params.from = from
+    if (to)   params.to   = to
+    const { data } = await clientApiClient.get(`/securities/${id}/history`, { params })
+    return data
   },
 
   async getStocks(opts = {}) {

--- a/src/services/securitiesService.js
+++ b/src/services/securitiesService.js
@@ -42,4 +42,16 @@ export const securitiesService = {
     const { data } = await apiClient.get(`/securities/${id}/history`, { params })
     return data
   },
+
+  async getStocks(opts = {}) {
+    return this.getListings({ ...opts, type: 'STOCK' })
+  },
+
+  async getFutures(opts = {}) {
+    return this.getListings({ ...opts, type: 'FUTURES_CONTRACT' })
+  },
+
+  async getForex(opts = {}) {
+    return this.getListings({ ...opts, type: 'FOREX_PAIR' })
+  },
 }

--- a/src/services/securitiesService.js
+++ b/src/services/securitiesService.js
@@ -12,13 +12,13 @@ export const securitiesService = {
     if (ticker)     params.ticker      = ticker
     if (name)       params.name        = name
     if (page        != null) params.page       = page
-    if (pageSize    != null) params.page_size  = pageSize
-    if (sortBy)     params.sort_by     = sortBy
-    if (sortOrder)  params.sort_order  = sortOrder
+    if (pageSize    != null) params.pageSize   = pageSize
+    if (sortBy)     params.sortBy      = sortBy
+    if (sortOrder)  params.sortOrder   = sortOrder
     const { data } = await apiClient.get('/securities', { params })
     return {
       ...data,
-      items: (data.items ?? data).map(listingFromApi),
+      items: (data.listings ?? data.items ?? data).map(listingFromApi),
     }
   },
 

--- a/src/services/securitiesService.js
+++ b/src/services/securitiesService.js
@@ -23,11 +23,24 @@ export const securitiesService = {
   },
 
   /**
-   * Fetch full listing detail including type-specific fields and 30-day history.
+   * Fetch full listing detail: summary, type-specific detail, and embedded 30-day history.
+   * Returns { listing, detail, priceHistory }.
+   */
+  async getListing(id) {
+    const { data } = await apiClient.get(`/securities/${id}`)
+    return {
+      listing:      listingFromApi(data.summary ?? data),
+      detail:       data.detail ?? null,
+      priceHistory: data.priceHistory ?? [],
+    }
+  },
+
+  /**
+   * @deprecated Use getListing() instead.
    */
   async getListingById(id) {
     const { data } = await apiClient.get(`/securities/${id}`)
-    return listingFromApi(data)
+    return listingFromApi(data.summary ?? data)
   },
 
   /**


### PR DESCRIPTION
Implements /securities (employee portal, all 3 tabs) and /client/securities (client portal, Stocks + Futures only). Includes search, filters, sort, per-row refresh, auto-refresh. NOTE: not tested locally due to environment issues.