### PR TITLE
feat: employee sidebar layout + portfolio pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import { AccountsProvider } from './context/AccountsContext'
 import { ClientAccountsProvider } from './context/ClientAccountsContext'
 import { ClientPaymentsProvider } from './context/ClientPaymentsContext'
 import { RecipientsProvider } from './context/RecipientsContext'
-import MainLayout from './layouts/MainLayout'
+import EmployeePortalLayout from './layouts/EmployeePortalLayout'
 import ProtectedRoute from './components/ProtectedRoute'
 import EmployeeHomePage from './pages/employee/EmployeeHomePage'
 import EmployeeLoginPage from './pages/employee/EmployeeLoginPage'
@@ -50,11 +50,13 @@ import ActuaryManagementPage from './pages/employee/ActuaryManagementPage'
 import StockExchangesPage from './pages/employee/StockExchangesPage'
 import CreateOrderPage from './pages/orders/CreateOrderPage'
 import OrderReviewPage from './pages/orders/OrderReviewPage'
+import PortfolioPage from './pages/orders/PortfolioPage'
 import SecuritiesPage from './pages/securities/SecuritiesPage'
 import ListingDetailPage from './pages/securities/ListingDetailPage'
 import StockOptionsPage from './pages/securities/StockOptionsPage'
 import ClientSecuritiesPage from './pages/client/ClientSecuritiesPage'
 import ClientListingDetailPage from './pages/client/ClientListingDetailPage'
+import ClientPortfolioPage from './pages/client/ClientPortfolioPage'
 import NotFoundPage from './pages/NotFoundPage'
 
 function App() {
@@ -70,11 +72,12 @@ function App() {
       <ClientsProvider>
       <AccountsProvider>
         <Routes>
-          {/* Public pages with Navbar + Footer */}
-          <Route element={<MainLayout />}>
-            <Route path="/" element={<EmployeeHomePage />} />
-            {/* Protected pages (still use Navbar + Footer layout) */}
-            <Route element={<ProtectedRoute />}>
+          {/* Home — handles both logged-in (sidebar) and logged-out (landing) */}
+          <Route path="/" element={<EmployeeHomePage />} />
+
+          {/* Protected pages — full-screen sidebar layout */}
+          <Route element={<ProtectedRoute />}>
+            <Route element={<EmployeePortalLayout />}>
               <Route path="/admin/employees" element={<AdminEmployeesPage />} />
               <Route path="/admin/employees/new" element={<NewEmployeePage />} />
               <Route path="/admin/employees/:id" element={<EmployeeDetailPage />} />
@@ -91,6 +94,7 @@ function App() {
               <Route path="/admin/stock-exchanges" element={<StockExchangesPage />} />
               <Route path="/admin/orders" element={<OrderReviewPage />} />
               <Route path="/orders/new" element={<CreateOrderPage />} />
+              <Route path="/portfolio" element={<PortfolioPage />} />
               <Route path="/securities" element={<SecuritiesPage />} />
               <Route path="/securities/:id" element={<ListingDetailPage />} />
               <Route path="/securities/:id/options" element={<StockOptionsPage />} />
@@ -124,6 +128,7 @@ function App() {
           <Route path="/client/recipients" element={<ClientRecipientsPage />} />
           <Route path="/client/securities" element={<ClientSecuritiesPage />} />
           <Route path="/client/securities/:id" element={<ClientListingDetailPage />} />
+          <Route path="/client/portfolio" element={<ClientPortfolioPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -69,6 +69,9 @@ function Navbar() {
             {user?.permissions?.isSupervisor && (
               <NavLink to="/admin/orders" className={linkClass}>Orders</NavLink>
             )}
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
+              <NavLink to="/portfolio" className={linkClass}>Portfolio</NavLink>
+            )}
           </div>
 
           {/* Desktop CTA */}
@@ -154,6 +157,9 @@ function Navbar() {
             )}
             {user?.permissions?.isSupervisor && (
               <NavLink to="/admin/orders" className={linkClass} onClick={() => setMenuOpen(false)}>Orders</NavLink>
+            )}
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
+              <NavLink to="/portfolio" className={linkClass} onClick={() => setMenuOpen(false)}>Portfolio</NavLink>
             )}
             <div className="flex items-center gap-4">
               <button

--- a/src/layouts/EmployeePortalLayout.jsx
+++ b/src/layouts/EmployeePortalLayout.jsx
@@ -1,35 +1,100 @@
 import { useState } from 'react'
-import { Link, useNavigate, useLocation } from 'react-router-dom'
+import { Link, NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { useTheme } from '../context/ThemeContext'
-import { useClientAuth } from '../context/ClientAuthContext'
+import { useAuth } from '../context/AuthContext'
 
 export const NAV_ITEMS = [
-  { label: 'Home',      href: '/client',           icon: 'M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z' },
-  { label: 'Accounts',  href: '/client/accounts',  icon: 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z' },
-  { label: 'Payments',  href: '/client/payments',  icon: 'M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z' },
-  { label: 'Transfers',  href: '/client/transfers',  icon: 'M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4' },
-  { label: 'Recipients', href: '/client/recipients', icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z' },
-  { label: 'Exchange',  href: '/client/exchange',  icon: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15' },
-  { label: 'Cards',     href: '/client/cards',     icon: 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z' },
-  { label: 'Loans',     href: '/client/loans',     icon: 'M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z' },
-  { label: 'Securities', href: '/client/securities', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z' },
-  { label: 'Portfolio',  href: '/client/portfolio',  icon: 'M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' },
+  {
+    label: 'Home',
+    href: '/',
+    exact: true,
+    icon: 'M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z',
+    show: () => true,
+  },
+  {
+    label: 'Employees',
+    href: '/admin/employees',
+    icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z',
+    show: (p) => p?.canManageEmployees,
+  },
+  {
+    label: 'Clients',
+    href: '/admin/clients',
+    icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
+    show: (p) => p?.canViewClients,
+  },
+  {
+    label: 'Accounts',
+    href: '/admin/accounts',
+    icon: 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z',
+    show: (p) => p?.canViewClients,
+  },
+  {
+    label: 'Bank Accounts',
+    href: '/admin/bank-accounts',
+    icon: 'M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z',
+    show: (p) => p?.isAdmin,
+  },
+  {
+    label: 'Loan Applications',
+    href: '/admin/loans/applications',
+    icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+    show: (p) => p?.canApproveLoans,
+  },
+  {
+    label: 'Loans',
+    href: '/admin/loans',
+    icon: 'M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z',
+    show: (p) => p?.canApproveLoans,
+  },
+  {
+    label: 'Actuaries',
+    href: '/admin/actuaries',
+    icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
+    show: (p) => p?.isSupervisor,
+  },
+  {
+    label: 'Stock Exchanges',
+    href: '/admin/stock-exchanges',
+    icon: 'M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9',
+    show: (p) => p?.isAgent || p?.isSupervisor,
+  },
+  {
+    label: 'Securities',
+    href: '/securities',
+    icon: 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6',
+    show: (p) => p?.isAgent || p?.isSupervisor,
+  },
+  {
+    label: 'Orders',
+    href: '/admin/orders',
+    icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2',
+    show: (p) => p?.isSupervisor,
+  },
+  {
+    label: 'Portfolio',
+    href: '/portfolio',
+    icon: 'M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z',
+    show: (p) => p?.isAgent || p?.isSupervisor,
+  },
 ]
 
-export default function ClientPortalLayout({ children }) {
+export default function EmployeePortalLayout() {
   const { dark, toggle } = useTheme()
-  const { clientUser, clientLogout } = useClientAuth()
+  const { user, logout } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
-  async function handleLogout() {
-    await clientLogout()
-    navigate('/client')
+  function handleLogout() {
+    logout()
+    navigate('/')
   }
 
-  const isActive = (href) =>
-    href === '/client' ? location.pathname === '/client' : location.pathname.startsWith(href)
+  const isActive = (href, exact) =>
+    exact ? location.pathname === href : location.pathname.startsWith(href)
+
+  const visibleItems = NAV_ITEMS.filter(item => item.show(user?.permissions))
 
   return (
     <div className="flex h-screen overflow-hidden bg-white dark:bg-slate-900">
@@ -47,14 +112,14 @@ export default function ClientPortalLayout({ children }) {
             </svg>
           </button>
         </div>
-        <nav className="flex-1 py-4">
-          {NAV_ITEMS.map((item) => (
+        <nav className="flex-1 py-4 overflow-y-auto">
+          {visibleItems.map((item) => (
             <Link
               key={item.href}
               to={item.href}
               title={!sidebarOpen ? item.label : undefined}
               className={`flex items-center gap-3 px-4 py-3 text-sm font-light transition-colors
-                ${isActive(item.href)
+                ${isActive(item.href, item.exact)
                   ? 'text-violet-700 dark:text-white bg-violet-100 dark:bg-violet-600/25 border-r-2 border-violet-500'
                   : 'text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/60 dark:hover:bg-slate-800/60'
                 }`}
@@ -70,11 +135,11 @@ export default function ClientPortalLayout({ children }) {
         </nav>
       </aside>
 
-      {/* Right: navbar + content */}
+      {/* Right: topbar + content */}
       <div className="flex-1 flex flex-col overflow-hidden">
         <nav className="bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-slate-800 shrink-0">
           <div className="flex items-center justify-between h-16 px-6">
-            <Link to="/client" className="flex items-center gap-3">
+            <Link to="/" className="flex items-center gap-3">
               <div className="w-7 h-7 border border-violet-500 dark:border-violet-400 flex items-center justify-center">
                 <span className="text-violet-500 dark:text-violet-400 text-xs font-serif font-semibold">A</span>
               </div>
@@ -83,9 +148,9 @@ export default function ClientPortalLayout({ children }) {
               </span>
             </Link>
             <div className="flex items-center gap-4">
-              {clientUser && (
+              {user && (
                 <span className="text-sm text-slate-500 dark:text-slate-400 font-light hidden sm:block">
-                  Welcome back, <span className="text-slate-900 dark:text-white font-medium">{clientUser.firstName} {clientUser.lastName}</span>
+                  Welcome back, <span className="text-slate-900 dark:text-white font-medium">{user.firstName} {user.lastName}</span>
                 </span>
               )}
               <button onClick={toggle} aria-label="Toggle dark mode" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white transition-colors">
@@ -109,9 +174,8 @@ export default function ClientPortalLayout({ children }) {
           </div>
         </nav>
 
-        {/* Page content */}
-        <main className="flex-1 overflow-auto">
-          {children}
+        <main className="flex-1 overflow-auto p-6">
+          <Outlet />
         </main>
       </div>
     </div>

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { clientPortfolioService } from '../../services/clientPortfolioService'
+import { fmt } from '../../utils/formatting'
+
+const TABS = [
+  { label: 'All Securities',    key: 'all' },
+  { label: 'Public Securities', key: 'public' },
+]
+
+function TypeBadge({ type }) {
+  return (
+    <span className="bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 text-xs px-2 py-0.5 rounded font-mono">
+      {type || '—'}
+    </span>
+  )
+}
+
+export default function ClientPortfolioPage() {
+  useWindowTitle('Portfolio | AnkaBanka')
+  const navigate = useNavigate()
+
+  const [holdings, setHoldings]   = useState([])
+  const [loading, setLoading]     = useState(true)
+  const [error, setError]         = useState(null)
+  const [activeTab, setActiveTab] = useState(TABS[0])
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    clientPortfolioService.getPortfolio()
+      .then(data => setHoldings(data.portfolio ?? []))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const displayed = activeTab.key === 'public'
+    ? holdings.filter(h => h.isPublic)
+    : holdings
+
+  return (
+    <ClientPortalLayout>
+      <div className="p-6">
+        {/* Header */}
+        <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white mb-1">My Portfolio</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">Current holdings and profit/loss</p>
+
+        {/* Tabs */}
+        <div className="flex gap-1 mb-5 border-b border-slate-200 dark:border-slate-700">
+          {TABS.map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab)}
+              className={`px-5 py-2.5 text-xs tracking-widest uppercase font-medium transition-colors border-b-2 -mb-px ${
+                activeTab.key === tab.key
+                  ? 'border-violet-500 text-violet-600 dark:text-violet-400'
+                  : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Table card */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-slate-500 dark:text-slate-400 text-sm">Loading holdings…</p>
+            </div>
+          ) : error ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-red-500 text-sm">Failed to load portfolio.</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Type', 'Ticker', 'Amount', 'Price', 'Profit', 'Last Modified', 'Public'].map(h => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                        {h}
+                      </th>
+                    ))}
+                    <th className="px-4 py-4" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {displayed.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                        {activeTab.key === 'public' ? 'No public holdings.' : 'No holdings found.'}
+                      </td>
+                    </tr>
+                  ) : (
+                    displayed.map((h, i) => (
+                      <tr
+                        key={h.id}
+                        className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                          i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
+                        }`}
+                      >
+                        <td className="px-4 py-3"><TypeBadge type={h.assetType} /></td>
+                        <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{h.ticker || h.listingId}</td>
+                        <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{h.amount}</td>
+                        <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{fmt(h.price ?? 0)}</td>
+                        <td className={`px-4 py-3 font-medium tabular-nums ${
+                          (h.profit ?? 0) >= 0
+                            ? 'text-emerald-600 dark:text-emerald-400'
+                            : 'text-red-500 dark:text-red-400'
+                        }`}>
+                          {(h.profit ?? 0) >= 0 ? '+' : ''}{fmt(h.profit ?? 0)}
+                        </td>
+                        <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">{h.lastModified}</td>
+                        <td className="px-4 py-3 text-slate-500 dark:text-slate-400 tabular-nums">
+                          {h.assetType === 'STOCK' ? h.publicAmount : '—'}
+                        </td>
+                        <td className="px-4 py-3">
+                          <button
+                            onClick={() => navigate(`/client/securities/${h.listingId}`)}
+                            className="border border-red-400 text-red-500 text-xs px-3 py-1 hover:bg-red-500 hover:text-white transition-all duration-150"
+                          >
+                            Sell
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {!loading && !error && displayed.length > 0 && (
+            <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+              {displayed.length} holding{displayed.length !== 1 ? 's' : ''}
+            </div>
+          )}
+        </div>
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/employee/EmployeeHomePage.jsx
+++ b/src/pages/employee/EmployeeHomePage.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useTheme } from '../../context/ThemeContext'
 import { useAuth } from '../../context/AuthContext'
+import Navbar from '../../components/Navbar'
+import { NAV_ITEMS } from '../../layouts/EmployeePortalLayout'
 
 const PERMISSION_META = {
   isAdmin: {
@@ -20,7 +22,7 @@ const PERMISSION_META = {
     description: 'Browse and search client profiles and account summaries.',
     icon: (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-4.5 0 2.625 2.625 0 014.5 0z" />
       </svg>
     ),
     accent: 'violet',
@@ -84,127 +86,205 @@ const ACCENT = {
 
 function EmployeeHomePage() {
   useWindowTitle('AnkaBanka — Employee Portal')
-  const { dark } = useTheme()
-  const { user } = useAuth()
+  const { dark, toggle } = useTheme()
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [sidebarOpen, setSidebarOpen] = useState(true)
   const [offset, setOffset] = useState({ x: 0, y: 0 })
-  const [blobsShifted, setBlobsShifted] = useState(false)
 
   useEffect(() => {
+    if (user) return
     const handleMouse = (e) => {
       const cx = window.innerWidth / 2
       const cy = window.innerHeight / 2
-      const dx = (e.clientX - cx) / cx
-      const dy = (e.clientY - cy) / cy
-      setOffset({ x: -dx * 45, y: -dy * 30 })
+      setOffset({ x: -((e.clientX - cx) / cx) * 45, y: -((e.clientY - cy) / cy) * 30 })
     }
     window.addEventListener('mousemove', handleMouse)
     return () => window.removeEventListener('mousemove', handleMouse)
-  }, [])
-
-  useEffect(() => {
-    if (!user) {
-      setBlobsShifted(false)
-      return
-    }
-    const t = setTimeout(() => setBlobsShifted(true), 60)
-    return () => clearTimeout(t)
   }, [user])
+
+  function handleLogout() {
+    logout()
+    navigate('/')
+  }
+
+  const isActive = (href, exact) =>
+    exact ? location.pathname === href : location.pathname.startsWith(href)
+
+  const visibleItems = NAV_ITEMS.filter(item => item.show(user?.permissions))
 
   const grantedPermissions = user
     ? Object.entries(user.permissions).filter(([, granted]) => granted)
     : []
 
-  return (
-    <div className="relative min-h-[680px] space-y-20">
-      {/* Blob container */}
-      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
-        <div
-          className="absolute w-[538px] h-[650px]"
-          style={{
-            top:    blobsShifted ? '-10%'  : '0',
-            left:   blobsShifted ? '10%'  : '38%',
-            transform: `translate(${offset.x}px, ${offset.y}px) rotate(18deg)`,
-            transition: 'top 0.9s cubic-bezier(0.25, 0.46, 0.45, 0.94), left 0.9s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 0.7s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-            background: dark
-              ? 'radial-gradient(ellipse at 50% 50%, rgba(126, 71, 255, 0.75) 0%, transparent 70%)'
-              : 'radial-gradient(ellipse at 50% 50%, rgba(138, 92, 246, 0.87) 0%, transparent 70%)',
-            filter: 'blur(64px)',
-          }}
-        />
-        <div
-          className="absolute w-[700px] h-[375px]"
-          style={{
-            top:    blobsShifted ? '55%' : '48px',
-            left:   blobsShifted ? '58%' : '30%',
-            transform: `translate(${offset.x * 0.55}px, ${offset.y * 0.55}px) rotate(-12deg)`,
-            transition: 'top 1.1s cubic-bezier(0.25, 0.46, 0.45, 0.94), left 1.1s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 1.1s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-            background: dark
-              ? 'radial-gradient(ellipse at 50% 50%, rgba(31, 132, 255, 0.9) 0%, transparent 70%)'
-              : 'radial-gradient(ellipse at 50% 50%, rgba(96, 165, 250, 0.88) 0%, transparent 70%)',
-            filter: 'blur(70px)',
-          }}
-        />
-      </div>
+  // ── Logged-in: full sidebar layout ──────────────────────────────────────────
+  if (user) {
+    return (
+      <div className="flex h-screen overflow-hidden bg-white dark:bg-slate-900">
 
-      {/* Hero */}
-      <section className="relative pt-8 pb-4">
-        <p className="section-label mb-6">Employee Portal</p>
-        <h1 className="font-serif text-5xl sm:text-6xl lg:text-7xl font-light text-slate-900 dark:text-white leading-tight mb-6">
-          AnkaBanka Internal
-        </h1>
-        <div className="gold-divider mx-0" />
-        {user ? (
-          <p className="text-slate-500 dark:text-slate-400 text-lg font-light max-w-lg mb-2 leading-relaxed">
-            Welcome back, <span className="text-slate-900 dark:text-white font-medium">{user.firstName}</span>.
-          </p>
-        ) : (
-          <>
+        {/* Sidebar */}
+        <aside className={`${sidebarOpen ? 'w-64' : 'w-16'} shrink-0 flex flex-col transition-[width] duration-500 ease-in-out overflow-hidden bg-slate-100 dark:bg-slate-950 border-r border-slate-100 dark:border-slate-800`}>
+          <div className="flex items-center justify-center h-16 border-b border-slate-100 dark:border-slate-800">
+            <button
+              onClick={() => setSidebarOpen(o => !o)}
+              className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white transition-colors p-2"
+              aria-label="Toggle sidebar"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+          </div>
+          <nav className="flex-1 py-4 overflow-y-auto">
+            {visibleItems.map((item) => (
+              <Link
+                key={item.href}
+                to={item.href}
+                title={!sidebarOpen ? item.label : undefined}
+                className={`flex items-center gap-3 px-4 py-3 text-sm font-light transition-colors
+                  ${isActive(item.href, item.exact)
+                    ? 'text-violet-700 dark:text-white bg-violet-100 dark:bg-violet-600/25 border-r-2 border-violet-500'
+                    : 'text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/60 dark:hover:bg-slate-800/60'
+                  }`}
+              >
+                <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d={item.icon} />
+                </svg>
+                <span className={`whitespace-nowrap transition-opacity duration-300 ${sidebarOpen ? 'opacity-100' : 'opacity-0'}`}>
+                  {item.label}
+                </span>
+              </Link>
+            ))}
+          </nav>
+        </aside>
+
+        {/* Right: topbar + content */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <nav className="bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-slate-800 shrink-0">
+            <div className="flex items-center justify-between h-16 px-6">
+              <Link to="/" className="flex items-center gap-3">
+                <div className="w-7 h-7 border border-violet-500 dark:border-violet-400 flex items-center justify-center">
+                  <span className="text-violet-500 dark:text-violet-400 text-xs font-serif font-semibold">A</span>
+                </div>
+                <span className="text-slate-900 dark:text-white font-serif text-lg tracking-widest font-light">
+                  Anka<span className="text-violet-600 dark:text-violet-400">Banka</span>
+                </span>
+              </Link>
+              <div className="flex items-center gap-4">
+                <span className="text-sm text-slate-500 dark:text-slate-400 font-light hidden sm:block">
+                  Welcome back, <span className="text-slate-900 dark:text-white font-medium">{user.firstName} {user.lastName}</span>
+                </span>
+                <button onClick={toggle} aria-label="Toggle dark mode" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white transition-colors">
+                  {dark ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                  )}
+                </button>
+                <button
+                  onClick={handleLogout}
+                  className="px-5 py-2 border border-violet-600 dark:border-violet-400 text-violet-600 dark:text-violet-400 text-xs tracking-widest uppercase font-medium hover:bg-violet-600 dark:hover:bg-violet-500 hover:text-white transition-all duration-200"
+                >
+                  Sign Out
+                </button>
+              </div>
+            </div>
+          </nav>
+
+          <main className="flex-1 overflow-auto">
+            <div className="max-w-5xl mx-auto px-6 py-10 w-full">
+              <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-6">
+                Your access
+              </p>
+              {grantedPermissions.length === 0 ? (
+                <p className="text-sm text-slate-400 dark:text-slate-500">
+                  You have no permissions assigned. Contact an administrator.
+                </p>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {grantedPermissions.map(([key]) => {
+                    const meta = PERMISSION_META[key]
+                    if (!meta) return null
+                    const accentClass = ACCENT[meta.accent]
+                    return (
+                      <div
+                        key={key}
+                        className={`rounded-xl border p-5 flex gap-4 items-start ${accentClass}`}
+                      >
+                        <div className="mt-0.5 shrink-0">{meta.icon}</div>
+                        <div>
+                          <p className="text-sm font-semibold tracking-wide mb-1">{meta.label}</p>
+                          <p className="text-xs font-light leading-relaxed opacity-80">{meta.description}</p>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </main>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Logged-out: landing page ─────────────────────────────────────────────────
+  return (
+    <div className="min-h-screen flex flex-col bg-white dark:bg-slate-900">
+      <Navbar />
+      <main className="flex-1 container mx-auto px-6 py-16 max-w-7xl">
+        <div className="relative min-h-[680px] space-y-20">
+
+          {/* Blobs */}
+          <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+            <div
+              className="absolute w-[538px] h-[650px]"
+              style={{
+                top: '-10%', left: '10%',
+                transform: `translate(${offset.x}px, ${offset.y}px) rotate(18deg)`,
+                transition: 'transform 0.7s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+                background: dark
+                  ? 'radial-gradient(ellipse at 50% 50%, rgba(126, 71, 255, 0.75) 0%, transparent 70%)'
+                  : 'radial-gradient(ellipse at 50% 50%, rgba(138, 92, 246, 0.87) 0%, transparent 70%)',
+                filter: 'blur(64px)',
+              }}
+            />
+            <div
+              className="absolute w-[700px] h-[375px]"
+              style={{
+                top: '48px', left: '30%',
+                transform: `translate(${offset.x * 0.55}px, ${offset.y * 0.55}px) rotate(-12deg)`,
+                transition: 'transform 1.1s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+                background: dark
+                  ? 'radial-gradient(ellipse at 50% 50%, rgba(31, 132, 255, 0.9) 0%, transparent 70%)'
+                  : 'radial-gradient(ellipse at 50% 50%, rgba(96, 165, 250, 0.88) 0%, transparent 70%)',
+                filter: 'blur(70px)',
+              }}
+            />
+          </div>
+
+          {/* Hero */}
+          <section className="relative pt-8 pb-4">
+            <p className="section-label mb-6">Employee Portal</p>
+            <h1 className="font-serif text-5xl sm:text-6xl lg:text-7xl font-light text-slate-900 dark:text-white leading-tight mb-6">
+              AnkaBanka Internal
+            </h1>
+            <div className="gold-divider mx-0" />
             <p className="text-slate-500 dark:text-slate-400 text-lg font-light max-w-lg mb-10 leading-relaxed">
               Internal tools and systems for AnkaBanka staff. Sign in with your employee credentials to continue.
             </p>
             <Link to="/login" className="btn-primary">
               Employee Login
             </Link>
-          </>
-        )}
-      </section>
+          </section>
 
-      {/* Permissions dashboard */}
-      {user && (
-        <section className="relative">
-          <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-6">
-            Your access
-          </p>
-
-          {grantedPermissions.length === 0 ? (
-            <p className="text-sm text-slate-400 dark:text-slate-500">
-              You have no permissions assigned. Contact an administrator.
-            </p>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {grantedPermissions.map(([key]) => {
-                const meta = PERMISSION_META[key]
-                if (!meta) return null
-                const accentClass = ACCENT[meta.accent]
-                return (
-                  <div
-                    key={key}
-                    className={`rounded-xl border p-5 flex gap-4 items-start ${accentClass}`}
-                  >
-                    <div className="mt-0.5 shrink-0">
-                      {meta.icon}
-                    </div>
-                    <div>
-                      <p className="text-sm font-semibold tracking-wide mb-1">{meta.label}</p>
-                      <p className="text-xs font-light leading-relaxed opacity-80">{meta.description}</p>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </section>
-      )}
+        </div>
+      </main>
     </div>
   )
 }

--- a/src/pages/orders/PortfolioPage.jsx
+++ b/src/pages/orders/PortfolioPage.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { portfolioService } from '../../services/portfolioService'
+import { fmt } from '../../utils/formatting'
+
+const TABS = [
+  { label: 'All Securities',    key: 'all' },
+  { label: 'Public Securities', key: 'public' },
+]
+
+function TypeBadge({ type }) {
+  return (
+    <span className="bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 text-xs px-2 py-0.5 rounded font-mono">
+      {type || '—'}
+    </span>
+  )
+}
+
+export default function PortfolioPage() {
+  useWindowTitle('Portfolio | AnkaBanka')
+  const navigate = useNavigate()
+
+  const [holdings, setHoldings]   = useState([])
+  const [loading, setLoading]     = useState(true)
+  const [error, setError]         = useState(null)
+  const [activeTab, setActiveTab] = useState(TABS[0])
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    portfolioService.getPortfolio()
+      .then(data => setHoldings(data.portfolio ?? []))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const displayed = activeTab.key === 'public'
+    ? holdings.filter(h => h.isPublic)
+    : holdings
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      {/* Header */}
+      <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white mb-1">My Portfolio</h1>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">Current holdings and profit/loss</p>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-5 border-b border-slate-200 dark:border-slate-700">
+        {TABS.map(tab => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab)}
+            className={`px-5 py-2.5 text-xs tracking-widest uppercase font-medium transition-colors border-b-2 -mb-px ${
+              activeTab.key === tab.key
+                ? 'border-violet-500 text-violet-600 dark:text-violet-400'
+                : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Table card */}
+      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <p className="text-slate-500 dark:text-slate-400 text-sm">Loading holdings…</p>
+          </div>
+        ) : error ? (
+          <div className="flex items-center justify-center py-20">
+            <p className="text-red-500 text-sm">Failed to load portfolio.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 dark:border-slate-700">
+                  {['Type', 'Ticker', 'Amount', 'Price', 'Profit', 'Last Modified', 'Public'].map(h => (
+                    <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">
+                      {h}
+                    </th>
+                  ))}
+                  <th className="px-4 py-4" />
+                </tr>
+              </thead>
+              <tbody>
+                {displayed.length === 0 ? (
+                  <tr>
+                    <td colSpan={8} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                      {activeTab.key === 'public' ? 'No public holdings.' : 'No holdings found.'}
+                    </td>
+                  </tr>
+                ) : (
+                  displayed.map((h, i) => (
+                    <tr
+                      key={h.id}
+                      className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                        i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
+                      }`}
+                    >
+                      <td className="px-4 py-3"><TypeBadge type={h.assetType} /></td>
+                      <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{h.ticker || h.listingId}</td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{h.amount}</td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{fmt(h.price ?? 0)}</td>
+                      <td className={`px-4 py-3 font-medium tabular-nums ${
+                        (h.profit ?? 0) >= 0
+                          ? 'text-emerald-600 dark:text-emerald-400'
+                          : 'text-red-500 dark:text-red-400'
+                      }`}>
+                        {(h.profit ?? 0) >= 0 ? '+' : ''}{fmt(h.profit ?? 0)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">{h.lastModified}</td>
+                      <td className="px-4 py-3 text-slate-500 dark:text-slate-400 tabular-nums">
+                        {h.assetType === 'STOCK' ? h.publicAmount : '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => navigate(`/orders/new?ticker=${encodeURIComponent(h.ticker)}&direction=SELL`)}
+                          className="border border-red-400 text-red-500 text-xs px-3 py-1 hover:bg-red-500 hover:text-white transition-all duration-150"
+                        >
+                          Sell
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {!loading && !error && displayed.length > 0 && (
+          <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+            {displayed.length} holding{displayed.length !== 1 ? 's' : ''}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/services/clientPortfolioService.js
+++ b/src/services/clientPortfolioService.js
@@ -1,0 +1,13 @@
+import { clientApiClient } from './clientApiClient'
+
+export const clientPortfolioService = {
+  async getPortfolio() {
+    const { data } = await clientApiClient.get('/portfolio')
+    return data
+  },
+
+  async getProfit() {
+    const { data } = await clientApiClient.get('/portfolio/profit')
+    return data
+  },
+}

--- a/src/services/portfolioService.js
+++ b/src/services/portfolioService.js
@@ -1,0 +1,13 @@
+import { apiClient } from './apiClient'
+
+export const portfolioService = {
+  async getPortfolio() {
+    const { data } = await apiClient.get('/portfolio')
+    return data
+  },
+
+  async getProfit() {
+    const { data } = await apiClient.get('/portfolio/profit')
+    return data
+  },
+}


### PR DESCRIPTION
## Summary
- Replace employee top navbar with a collapsible sidebar layout matching the client portal — `EmployeePortalLayout` handles all protected routes, `EmployeeHomePage` handles both logged-in (sidebar) and logged-out (landing) states
- Add employee `PortfolioPage` (`/portfolio`) and client `ClientPortfolioPage` (`/client/portfolio`) showing holdings table with type, ticker, amount, price, profit, and a Sell button
- Add `portfolioService` and `clientPortfolioService` for API calls
- Fix portfolio Sell button to use query params (`?ticker=...&direction=SELL`) instead of router state, which `CreateOrderPage` already expects via `useSearchParams`

## Test plan
- [ ] Not logged in → `/` shows landing page with top navbar and Employee Login button
- [ ] Log in as employee → `/` shows sidebar with permissions dashboard
- [ ] Sidebar collapses to icons, nav items are permission-gated correctly
- [ ] Agent/supervisor sees Portfolio and Securities in sidebar; admin does not
- [ ] `/portfolio` shows holdings table; Sell button opens create order page pre-filled
- [ ] `/client/portfolio` shows client holdings

🤖 Generated with [Claude Code](https://claude.com/claude-code)