### PR TITLE
fix: wire client buy/sell order navigation and add agent limit editing

### DIFF
--- a/src/pages/client/ClientListingDetailPage.jsx
+++ b/src/pages/client/ClientListingDetailPage.jsx
@@ -110,10 +110,16 @@ export default function ClientListingDetailPage() {
           </div>
           <div className="flex items-center gap-4 mt-1">
             <button
-              onClick={() => navigate(`/client/orders/new?ticker=${listing.ticker}&direction=BUY`)}
+              onClick={() => navigate(`/client/orders/new?ticker=${encodeURIComponent(listing.ticker)}&direction=BUY`)}
               className="btn-primary"
             >
               Buy
+            </button>
+            <button
+              onClick={() => navigate(`/client/orders/new?ticker=${encodeURIComponent(listing.ticker)}&direction=SELL`)}
+              className="border border-red-400 text-red-500 text-sm px-4 py-2 rounded-lg hover:bg-red-500 hover:text-white transition-all duration-150"
+            >
+              Sell
             </button>
             <Link to="/client/securities" className="text-sm text-violet-600 dark:text-violet-400 hover:underline">
               ← Back

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -119,7 +119,7 @@ export default function ClientPortfolioPage() {
                         </td>
                         <td className="px-4 py-3">
                           <button
-                            onClick={() => navigate(`/client/securities/${h.listingId}`)}
+                            onClick={() => navigate(`/client/orders/new?ticker=${encodeURIComponent(h.ticker || h.listingId)}&direction=SELL`)}
                             className="border border-red-400 text-red-500 text-xs px-3 py-1 hover:bg-red-500 hover:text-white transition-all duration-150"
                           >
                             Sell

--- a/src/pages/client/ClientSecuritiesPage.jsx
+++ b/src/pages/client/ClientSecuritiesPage.jsx
@@ -329,7 +329,7 @@ export default function ClientSecuritiesPage() {
                           <td className="px-4 py-3">
                             <div className="flex items-center gap-2 justify-end">
                               <button
-                                onClick={() => navigate(`/client/securities/${l.id}/order`)}
+                                onClick={() => navigate(`/client/orders/new?ticker=${encodeURIComponent(l.ticker)}&direction=BUY`)}
                                 className="btn-primary text-xs px-3 py-1"
                               >
                                 Buy

--- a/src/pages/employee/ActuaryManagementPage.jsx
+++ b/src/pages/employee/ActuaryManagementPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { actuaryService } from '../../services/actuaryService'
+import { ActuaryInfo } from '../../models/ActuaryInfo'
 import { fmt } from '../../utils/formatting'
 import PermissionGate from '../../components/PermissionGate'
 import { PERM } from '../../utils/permissions'
@@ -49,7 +50,7 @@ export default function ActuaryManagementPage() {
     try {
       await actuaryService.setAgentLimit(agentId, val)
       setActuaries((prev) =>
-        prev.map((a) => a.employeeId === agentId ? { ...a, limit: val } : a)
+        prev.map((a) => a.employeeId === agentId ? new ActuaryInfo({ ...a, limit: val }) : a)
       )
       setEditingLimit(null)
     } catch {
@@ -61,7 +62,7 @@ export default function ActuaryManagementPage() {
     try {
       await actuaryService.resetAgentUsedLimit(agentId)
       setActuaries((prev) =>
-        prev.map((a) => a.employeeId === agentId ? { ...a, usedLimit: 0 } : a)
+        prev.map((a) => a.employeeId === agentId ? new ActuaryInfo({ ...a, usedLimit: 0 }) : a)
       )
     } catch {
       // error dispatched by apiClient interceptor

--- a/src/pages/employee/EmployeeDetailPage.jsx
+++ b/src/pages/employee/EmployeeDetailPage.jsx
@@ -97,6 +97,8 @@ export default function EmployeeDetailPage() {
       .catch(() => {})
   }, [emp?.id, emp?.permissions?.isAgent, emp?.permissions?.isSupervisor])
 
+  const [agentForm, setAgentForm] = useState({ limit: 0, usedLimit: 0, needApproval: false })
+
   if (!emp) {
     return (
       <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center text-center px-6">
@@ -125,6 +127,11 @@ export default function EmployeeDetailPage() {
       permissions: { ...emp.permissions },
     })
     setSelectedRole(role)
+    setAgentForm(
+      actuaryInfo
+        ? { limit: actuaryInfo.limit ?? 0, usedLimit: actuaryInfo.usedLimit ?? 0, needApproval: actuaryInfo.needApproval ?? false }
+        : { limit: 0, usedLimit: 0, needApproval: false }
+    )
     setEditing(true)
   }
 
@@ -148,6 +155,11 @@ export default function EmployeeDetailPage() {
     const { name, value, type, checked } = e.target
     setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
     if (fieldErrors[name]) setFieldErrors((prev) => ({ ...prev, [name]: '' }))
+  }
+
+  function handleAgentChange(e) {
+    const { name, value, type, checked } = e.target
+    setAgentForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
   }
 
   function handleBlur(e) {
@@ -186,6 +198,15 @@ export default function EmployeeDetailPage() {
     setFieldErrors({})
     try {
       await updateEmployee(emp.id, form)
+      if (selectedRole === 'agent') {
+        await actuaryService.setAgentLimit(emp.id, Number(agentForm.limit))
+        await actuaryService.setNeedApproval(emp.id, agentForm.needApproval)
+        if (Number(agentForm.usedLimit) === 0 && (actuaryInfo?.usedLimit ?? 0) !== 0) {
+          await actuaryService.resetAgentUsedLimit(emp.id)
+        }
+        const list = await actuaryService.getActuaries()
+        setActuaryInfo(list.find((a) => a.employeeId === emp.id) ?? null)
+      }
       setEditing(false)
     } catch {
       // keep editing open so user can retry
@@ -294,6 +315,35 @@ export default function EmployeeDetailPage() {
                   ))}
                 </div>
               </Section>
+
+              {selectedRole === 'agent' && (
+                <Section title="Agent Limits">
+                  <EditRow
+                    label="Limit (RSD)"
+                    name="limit"
+                    type="number"
+                    value={agentForm.limit}
+                    onChange={handleAgentChange}
+                  />
+                  <EditRow
+                    label="Used Limit (RSD)"
+                    name="usedLimit"
+                    type="number"
+                    value={agentForm.usedLimit}
+                    onChange={handleAgentChange}
+                  />
+                  <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800 last:border-0">
+                    <span className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400">Need Approval</span>
+                    <input
+                      type="checkbox"
+                      name="needApproval"
+                      checked={agentForm.needApproval}
+                      onChange={handleAgentChange}
+                      className="w-4 h-4 accent-violet-600"
+                    />
+                  </div>
+                </Section>
+              )}
 
               <div className="flex gap-3 pt-4">
                 <button


### PR DESCRIPTION
- ClientSecuritiesPage: fix Buy button to navigate to /client/orders/new instead of non-existent /order route
- ClientListingDetailPage: encode ticker in URL, add Sell button
- ClientPortfolioPage: fix Sell button to navigate to order form instead of listing detail
- EmployeeDetailPage: add agent limit/usedLimit/needApproval fields in edit mode, save via actuaryService on submit
- ActuaryManagementPage: wrap updated actuary objects in ActuaryInfo constructor to preserve methods