### PR TITLE
fix(employee): make address required on new employee form

### DIFF
--- a/cypress/e2e/celina1/employee-creation.cy.js
+++ b/cypress/e2e/celina1/employee-creation.cy.js
@@ -83,6 +83,7 @@ describe('Kreiranje i aktivacija zaposlenog — scenarios 6–10', () => {
     cy.get('input[name="lastName"]').type('Test')
     cy.get('input[name="email"]').type('marko@banka.rs') // already exists
     cy.get('input[name="username"]').type(`duplicate_${Date.now()}`)
+    cy.get('input[name="address"]').type('Test Street 1')
     cy.get('input[name="position"]').type('Agent')
     cy.get('input[name="department"]').type('IT')
     cy.get('input[name="jmbg"]').type('9999999999999')

--- a/src/pages/employee/NewEmployeePage.jsx
+++ b/src/pages/employee/NewEmployeePage.jsx
@@ -19,7 +19,7 @@ const EMPTY_FORM = {
   permissions: { ...DEFAULT_PERMISSIONS },
 }
 
-const REQUIRED = ['firstName', 'lastName', 'email', 'username', 'position', 'department']
+const REQUIRED = ['firstName', 'lastName', 'email', 'username', 'position', 'department', 'address']
 
 export default function NewEmployeePage() {
   useWindowTitle('New Employee | AnkaBanka Admin')
@@ -129,8 +129,8 @@ export default function NewEmployeePage() {
                   <input className="input-field" name="phoneNumber" value={form.phoneNumber} onChange={handleChange} placeholder="+381..." />
                 </Field>
               </div>
-              <Field label="Address">
-                <input className="input-field" name="address" value={form.address} onChange={handleChange} placeholder="Street, City" />
+              <Field label="Address" required error={errors.address}>
+                <input className="input-field" name="address" value={form.address} onChange={handleChange} onBlur={handleBlur} placeholder="Street, City" />
               </Field>
             </FormSection>
 


### PR DESCRIPTION
## Summary

- Address was missing from the `REQUIRED` array in `NewEmployeePage.jsx`, so the form allowed submission without it
- The API Gateway already enforces `address` as `binding:"required"`, causing silent 400 failures
- Added `address` to the required fields list, asterisk indicator, error styling, and `onBlur` validation

## Test plan

- [ ] Open new employee form — Address field shows an asterisk
- [ ] Submit without filling Address — form stays open with error styling on the Address field
- [ ] Fill in Address and submit — proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)