### PR TITLE
fix: tax page hooks violation and correct portfolio tax API path

### DIFF
--- a/src/pages/tax/TaxTrackingPage.jsx
+++ b/src/pages/tax/TaxTrackingPage.jsx
@@ -15,7 +15,6 @@ const TYPE_BADGE = {
 export default function TaxTrackingPage() {
   useWindowTitle('Tax Tracking | AnkaBanka')
   const { canAny } = usePermission()
-  if (!canAny(['isSupervisor', 'isAdmin'])) return <Navigate to="/" replace />
 
   const [entries,    setEntries]    = useState([])
   const [loading,    setLoading]    = useState(true)
@@ -23,6 +22,8 @@ export default function TaxTrackingPage() {
   const [typeFilter, setTypeFilter] = useState('ALL')
   const [nameInput,  setNameInput]  = useState('')
   const [nameFilter, setNameFilter] = useState('')
+
+  if (!canAny(['isSupervisor', 'isAdmin'])) return <Navigate to="/" replace />
 
   useEffect(() => {
     const id = setTimeout(() => setNameFilter(nameInput.trim()), 300)
@@ -50,6 +51,8 @@ export default function TaxTrackingPage() {
     try {
       await taxService.collectTax()
       load()
+    } catch {
+      // error toast handled by Axios interceptor
     } finally {
       setCollecting(false)
     }

--- a/src/services/portfolioService.js
+++ b/src/services/portfolioService.js
@@ -12,7 +12,7 @@ export const portfolioService = {
   },
 
   async getMyTax() {
-    const { data } = await apiClient.get('/client/tax/my')
+    const { data } = await apiClient.get('/tax/my')
     return data
   },
 }


### PR DESCRIPTION
Move useState calls above the permission guard to comply with React rules of hooks. Fix getMyTax endpoint from /client/tax/my to /tax/my.