### PR TITLE
feat: OTC Trading and Investment Funds portal (Sprint-7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.20",
-        "cypress": "^15.12.0",
+        "cypress": "^15.14.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.13",
         "vite": "^5.4.8"
@@ -1432,54 +1432,17 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^0.21.3"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1578,16 +1541,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/asynckit": {
@@ -1986,27 +1939,20 @@
         "node": ">=8"
       }
     },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "restore-cursor": "^3.1.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-table3": {
@@ -2026,20 +1972,66 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -2170,9 +2162,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.12.0.tgz",
-      "integrity": "sha512-B2BRcudLfA4NZZP5QpA45J70bu1heCH59V1yKRLHAtiC49r7RV03X5ifUh7Nfbk8QNg93RAsc6oAmodm/+j0pA==",
+      "version": "15.14.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.14.2.tgz",
+      "integrity": "sha512-xMWg/iEImeIThRQZdnf3BFJT1a84apM/R91Feoa4vVWGuYWDphMT5jLhRVTBVlCgi+6axegF1zqhNyjhug2SsQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2186,25 +2178,22 @@
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
-        "cachedir": "^2.3.0",
+        "cachedir": "^2.4.0",
         "chalk": "^4.1.0",
         "ci-info": "^4.1.0",
-        "cli-cursor": "^3.1.0",
         "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
         "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
-        "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
-        "listr2": "^3.8.3",
+        "listr2": "^9.0.5",
         "lodash": "^4.17.23",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.8",
@@ -2492,18 +2481,17 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
       "engines": {
-        "node": ">=8.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -2598,16 +2586,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/eventemitter2": {
@@ -2757,22 +2735,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2894,6 +2856,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3118,16 +3093,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/ini": {
       "version": "2.0.0",
@@ -3407,32 +3372,29 @@
       "license": "MIT"
     },
     "node_modules/listr2": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
+        "node": ">=20.0.0"
       }
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.23",
@@ -3465,55 +3427,98 @@
       }
     },
     "node_modules/log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/loose-envify": {
@@ -3607,6 +3612,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimist": {
@@ -3751,22 +3769,6 @@
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4287,17 +4289,49 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/reusify": {
@@ -4386,23 +4420,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -4558,18 +4575,49 @@
       "license": "ISC"
     },
     "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map-js": {
@@ -4795,13 +4843,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -5157,21 +5198,88 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,13 @@ import ClientListingDetailPage from './pages/client/ClientListingDetailPage'
 import ClientPortfolioPage from './pages/client/ClientPortfolioPage'
 import ClientCreateOrderPage from './pages/client/ClientCreateOrderPage'
 import TaxTrackingPage from './pages/tax/TaxTrackingPage'
+import OtcMarketPage from './pages/otc/OtcMarketPage'
+import OtcNegotiationsPage from './pages/otc/OtcNegotiationsPage'
+import OtcNegotiationDetailPage from './pages/otc/OtcNegotiationDetailPage'
+import OtcContractsPage from './pages/otc/OtcContractsPage'
+import FundsDiscoveryPage from './pages/investment/FundsDiscoveryPage'
+import CreateFundPage from './pages/investment/CreateFundPage'
+import FundDetailPage from './pages/investment/FundDetailPage'
 import NotFoundPage from './pages/NotFoundPage'
 
 function App() {
@@ -101,6 +108,13 @@ function App() {
               <Route path="/securities" element={<SecuritiesPage />} />
               <Route path="/securities/:id" element={<ListingDetailPage />} />
               <Route path="/securities/:id/options" element={<StockOptionsPage />} />
+              <Route path="/otc/market"              element={<OtcMarketPage />} />
+              <Route path="/otc/negotiations"        element={<OtcNegotiationsPage />} />
+              <Route path="/otc/negotiations/:id"    element={<OtcNegotiationDetailPage />} />
+              <Route path="/otc/contracts"           element={<OtcContractsPage />} />
+              <Route path="/investment/funds"        element={<FundsDiscoveryPage />} />
+              <Route path="/investment/funds/new"    element={<CreateFundPage />} />
+              <Route path="/investment/funds/:id"    element={<FundDetailPage />} />
             </Route>
           </Route>
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -72,6 +72,12 @@ function Navbar() {
             {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
               <NavLink to="/portfolio" className={linkClass}>Portfolio</NavLink>
             )}
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor || user?.permissions?.isAdmin) && (
+              <NavLink to="/otc/negotiations" className={linkClass}>OTC Trading</NavLink>
+            )}
+            {user && (
+              <NavLink to="/investment/funds" className={linkClass}>Investment Funds</NavLink>
+            )}
           </div>
 
           {/* Desktop CTA */}
@@ -160,6 +166,12 @@ function Navbar() {
             )}
             {(user?.permissions?.isAgent || user?.permissions?.isSupervisor) && (
               <NavLink to="/portfolio" className={linkClass} onClick={() => setMenuOpen(false)}>Portfolio</NavLink>
+            )}
+            {(user?.permissions?.isAgent || user?.permissions?.isSupervisor || user?.permissions?.isAdmin) && (
+              <NavLink to="/otc/negotiations" className={linkClass} onClick={() => setMenuOpen(false)}>OTC Trading</NavLink>
+            )}
+            {user && (
+              <NavLink to="/investment/funds" className={linkClass} onClick={() => setMenuOpen(false)}>Investment Funds</NavLink>
             )}
             <div className="flex items-center gap-4">
               <button

--- a/src/layouts/EmployeePortalLayout.jsx
+++ b/src/layouts/EmployeePortalLayout.jsx
@@ -83,6 +83,18 @@ export const NAV_ITEMS = [
     icon: 'M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z',
     show: (p) => p?.isSupervisor || p?.isAdmin,
   },
+  {
+    label: 'OTC Trading',
+    href: '/otc/negotiations',
+    icon: 'M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4',
+    show: (p) => p?.isAgent || p?.isSupervisor || p?.isAdmin,
+  },
+  {
+    label: 'Investment Funds',
+    href: '/investment/funds',
+    icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    show: () => true,
+  },
 ]
 
 export default function EmployeePortalLayout() {

--- a/src/pages/investment/CreateFundPage.jsx
+++ b/src/pages/investment/CreateFundPage.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { useAuth } from '../../context/AuthContext'
+
+export default function CreateFundPage() {
+  useWindowTitle('Create Fund | AnkaBanka')
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (user && !user.permissions?.isSupervisor) {
+      navigate('/investment/funds', { replace: true })
+    }
+  }, [user, navigate])
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Create Fund</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+        <p className="text-slate-500 dark:text-slate-400 text-sm">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/investment/CreateFundPage.jsx
+++ b/src/pages/investment/CreateFundPage.jsx
@@ -1,12 +1,19 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
+import { actuaryService } from '../../services/actuaryService'
+import { fundService } from '../../services/fundService'
 
 export default function CreateFundPage() {
   useWindowTitle('Create Fund | AnkaBanka')
   const { user } = useAuth()
   const navigate = useNavigate()
+
+  const [actuaries, setActuaries] = useState([])
+  const [form, setForm] = useState({ name: '', description: '', minimumContribution: '', managerId: '' })
+  const [errors, setErrors] = useState({})
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     if (user && !user.permissions?.isSupervisor) {
@@ -14,13 +21,131 @@ export default function CreateFundPage() {
     }
   }, [user, navigate])
 
+  useEffect(() => {
+    actuaryService.getActuaries().then(setActuaries).catch(() => {})
+  }, [])
+
+  function handleChange(e) {
+    const { name, value } = e.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+    setErrors((prev) => ({ ...prev, [name]: undefined }))
+  }
+
+  function validate() {
+    const errs = {}
+    if (!form.name.trim()) errs.name = 'Fund name is required.'
+    if (!form.minimumContribution) errs.minimumContribution = 'Minimum contribution is required.'
+    else if (parseFloat(form.minimumContribution) <= 0) errs.minimumContribution = 'Must be greater than 0.'
+    if (!form.managerId) errs.managerId = 'Please select a manager.'
+    return errs
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const errs = validate()
+    if (Object.keys(errs).length > 0) { setErrors(errs); return }
+
+    setSubmitting(true)
+    try {
+      await fundService.createFund({
+        name: form.name.trim(),
+        description: form.description.trim(),
+        minimumContribution: parseFloat(form.minimumContribution),
+        managerId: parseInt(form.managerId, 10),
+      })
+      navigate('/investment/funds', { replace: true })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-2xl mx-auto">
         <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
         <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Create Fund</h1>
         <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
-        <p className="text-slate-500 dark:text-slate-400 text-sm">Coming soon.</p>
+
+        <form onSubmit={handleSubmit} noValidate className="space-y-6">
+          <div>
+            <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-2">
+              Fund Name <span className="text-violet-500">*</span>
+            </label>
+            <input
+              type="text"
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              className={`input-field ${errors.name ? 'input-error' : ''}`}
+              placeholder="e.g. Growth Equity Fund"
+            />
+            {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
+          </div>
+
+          <div>
+            <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-2">
+              Description
+            </label>
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              rows={3}
+              className="input-field resize-none"
+              placeholder="Optional description of the fund's strategy"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-2">
+              Minimum Contribution (RSD) <span className="text-violet-500">*</span>
+            </label>
+            <input
+              type="number"
+              name="minimumContribution"
+              value={form.minimumContribution}
+              onChange={handleChange}
+              min="0.01"
+              step="0.01"
+              className={`input-field ${errors.minimumContribution ? 'input-error' : ''}`}
+              placeholder="e.g. 1000"
+            />
+            {errors.minimumContribution && <p className="mt-1 text-xs text-red-500">{errors.minimumContribution}</p>}
+          </div>
+
+          <div>
+            <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-2">
+              Fund Manager <span className="text-violet-500">*</span>
+            </label>
+            <select
+              name="managerId"
+              value={form.managerId}
+              onChange={handleChange}
+              className={`input-field appearance-none ${errors.managerId ? 'input-error' : ''}`}
+            >
+              <option value="">Select a manager</option>
+              {actuaries.map((a) => (
+                <option key={a.employeeId} value={a.employeeId}>
+                  {a.fullName} — {a.position}
+                </option>
+              ))}
+            </select>
+            {errors.managerId && <p className="mt-1 text-xs text-red-500">{errors.managerId}</p>}
+          </div>
+
+          <div className="flex items-center gap-4 pt-2">
+            <button type="submit" disabled={submitting} className="btn-primary disabled:opacity-50">
+              {submitting ? 'Creating…' : 'Create Fund'}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate('/investment/funds')}
+              className="text-xs tracking-widest uppercase text-slate-500 hover:text-slate-900 dark:hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   )

--- a/src/pages/investment/FundDetailPage.jsx
+++ b/src/pages/investment/FundDetailPage.jsx
@@ -1,0 +1,15 @@
+import useWindowTitle from '../../hooks/useWindowTitle'
+
+export default function FundDetailPage() {
+  useWindowTitle('Fund Detail | AnkaBanka')
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Fund Detail</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+        <p className="text-slate-500 dark:text-slate-400 text-sm">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/investment/FundsDiscoveryPage.jsx
+++ b/src/pages/investment/FundsDiscoveryPage.jsx
@@ -1,0 +1,467 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { useAuth } from '../../context/AuthContext'
+import { fundService } from '../../services/fundService'
+import { accountService } from '../../services/accountService'
+import { fmt } from '../../utils/formatting'
+
+function truncate(s, n = 80) {
+  return s?.length > n ? s.slice(0, n) + '…' : (s ?? '—')
+}
+
+// ── Invest Modal ──────────────────────────────────────────────────────────────
+
+function InvestModal({ fund, onClose, onSuccess }) {
+  const [amount, setAmount]                   = useState('')
+  const [sourceAccountId, setSourceAccountId] = useState('')
+  const [accounts, setAccounts]               = useState([])
+  const [accountsLoading, setAccountsLoading] = useState(true)
+  const [amountError, setAmountError]         = useState('')
+  const [submitting, setSubmitting]           = useState(false)
+
+  useEffect(() => {
+    accountService.getAccounts()
+      .then(list => {
+        setAccounts(list)
+        if (list.length > 0) setSourceAccountId(String(list[0].id))
+      })
+      .catch(() => setAccounts([]))
+      .finally(() => setAccountsLoading(false))
+  }, [])
+
+  function validateAmount(val) {
+    const n = Number(val)
+    if (!val || isNaN(n) || n <= 0) {
+      setAmountError('Please enter a valid amount.')
+      return false
+    }
+    if (n < fund.minimumContribution) {
+      setAmountError(`Minimum contribution is ${fmt(fund.minimumContribution, 'RSD')}.`)
+      return false
+    }
+    setAmountError('')
+    return true
+  }
+
+  async function handleSubmit() {
+    if (!validateAmount(amount)) return
+    setSubmitting(true)
+    try {
+      await fundService.invest(fund.id, { sourceAccountId: Number(sourceAccountId), amount: Number(amount) })
+      onSuccess()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-md mx-4 overflow-hidden"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+          <div>
+            <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-0.5">Invest</p>
+            <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">{fund.name}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors text-2xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-6 py-5 flex flex-col gap-4">
+          <div>
+            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">
+              Amount (RSD) — minimum {fmt(fund.minimumContribution, 'RSD')}
+            </label>
+            <input
+              type="number"
+              value={amount}
+              onChange={e => { setAmount(e.target.value); setAmountError('') }}
+              onBlur={() => amount && validateAmount(amount)}
+              placeholder={`${fund.minimumContribution}`}
+              className={`input-field w-full text-sm${amountError ? ' input-error' : ''}`}
+            />
+            {amountError && (
+              <p className="text-xs text-red-500 mt-1">{amountError}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Source Account</label>
+            {accountsLoading ? (
+              <p className="text-xs text-slate-400">Loading accounts…</p>
+            ) : accounts.length === 0 ? (
+              <p className="text-xs text-slate-400">No accounts available.</p>
+            ) : (
+              <select
+                value={sourceAccountId}
+                onChange={e => setSourceAccountId(e.target.value)}
+                className="input-field w-full text-sm"
+              >
+                {accounts.map(a => (
+                  <option key={a.id} value={a.id}>
+                    {a.accountNumber} — {a.accountName ?? a.currencyCode}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </div>
+
+        <div className="px-6 pb-6 pt-2 border-t border-slate-100 dark:border-slate-800 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="text-xs tracking-widest uppercase font-medium text-slate-500 hover:text-slate-800 dark:hover:text-slate-200 transition-colors px-4 py-2"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || accountsLoading || accounts.length === 0}
+            className="btn-primary text-xs px-5 py-2 disabled:opacity-50"
+          >
+            {submitting ? 'Investing…' : 'Invest'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Bank Deposit Modal ────────────────────────────────────────────────────────
+
+function BankDepositModal({ fund, onClose, onSuccess }) {
+  const [amount, setAmount]           = useState('')
+  const [bankAccountId, setBankAccountId] = useState('')
+  const [accounts, setAccounts]       = useState([])
+  const [accountsLoading, setAccountsLoading] = useState(true)
+  const [submitting, setSubmitting]   = useState(false)
+
+  useEffect(() => {
+    accountService.getAccounts()
+      .then(list => {
+        const rsd = list.filter(a => a.currencyCode === 'RSD')
+        setAccounts(rsd)
+        if (rsd.length > 0) setBankAccountId(String(rsd[0].id))
+      })
+      .catch(() => setAccounts([]))
+      .finally(() => setAccountsLoading(false))
+  }, [])
+
+  async function handleSubmit() {
+    if (!amount || Number(amount) <= 0) return
+    setSubmitting(true)
+    try {
+      // POST /investment/funds/:id/invest (bank deposit uses same endpoint with bank account)
+      await fundService.invest(fund.id, { sourceAccountId: Number(bankAccountId), amount: Number(amount) })
+      onSuccess()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-md mx-4 overflow-hidden"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+          <div>
+            <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-0.5">Bank Deposit</p>
+            <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">{fund.name}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors text-2xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-6 py-5 flex flex-col gap-4">
+          <div>
+            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Amount (RSD)</label>
+            <input
+              type="number"
+              value={amount}
+              onChange={e => setAmount(e.target.value)}
+              placeholder="0.00"
+              className="input-field w-full text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Bank Account (RSD)</label>
+            {accountsLoading ? (
+              <p className="text-xs text-slate-400">Loading accounts…</p>
+            ) : accounts.length === 0 ? (
+              <p className="text-xs text-slate-400">No RSD bank accounts available.</p>
+            ) : (
+              <select
+                value={bankAccountId}
+                onChange={e => setBankAccountId(e.target.value)}
+                className="input-field w-full text-sm"
+              >
+                {accounts.map(a => (
+                  <option key={a.id} value={a.id}>
+                    {a.accountNumber} — {a.accountName ?? a.currencyCode}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </div>
+
+        <div className="px-6 pb-6 pt-2 border-t border-slate-100 dark:border-slate-800 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="text-xs tracking-widest uppercase font-medium text-slate-500 hover:text-slate-800 dark:hover:text-slate-200 transition-colors px-4 py-2"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || accountsLoading || accounts.length === 0 || !amount}
+            className="btn-primary text-xs px-5 py-2 disabled:opacity-50"
+          >
+            {submitting ? 'Depositing…' : 'Deposit'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
+
+export default function FundsDiscoveryPage() {
+  useWindowTitle('Investment Funds | AnkaBanka')
+  const { user } = useAuth()
+  const navigate  = useNavigate()
+
+  const [funds, setFunds]         = useState([])
+  const [loading, setLoading]     = useState(true)
+  const [error, setError]         = useState(null)
+  const [search, setSearch]       = useState('')
+  const [sortCol, setSortCol]     = useState(null)
+  const [sortOrder, setSortOrder] = useState('ASC')
+  const [investModal, setInvestModal]   = useState(null)
+  const [depositModal, setDepositModal] = useState(null)
+
+  const isSupervisor = user?.permissions?.isSupervisor
+  const isAgent      = user?.permissions?.isAgent
+
+  const loadFunds = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await fundService.getFunds()
+      setFunds(Array.isArray(data) ? data : (data.funds ?? data.items ?? []))
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadFunds() }, [loadFunds])
+
+  function handleSort(col) {
+    if (sortCol === col) {
+      setSortOrder(o => o === 'ASC' ? 'DESC' : 'ASC')
+    } else {
+      setSortCol(col)
+      setSortOrder('ASC')
+    }
+  }
+
+  function SortIcon({ col }) {
+    if (sortCol !== col) return <span className="text-slate-300 dark:text-slate-600 ml-1">↕</span>
+    return <span className="text-violet-500 ml-1">{sortOrder === 'ASC' ? '↑' : '↓'}</span>
+  }
+
+  const filtered = funds.filter(f =>
+    !search || f.name?.toLowerCase().includes(search.toLowerCase())
+  )
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (!sortCol) return 0
+    const va = a[sortCol]
+    const vb = b[sortCol]
+    if (va == null && vb == null) return 0
+    if (va == null) return 1
+    if (vb == null) return -1
+    const cmp = va - vb
+    return sortOrder === 'ASC' ? cmp : -cmp
+  })
+
+  function thClass(sortable) {
+    return `px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap${
+      sortable ? ' cursor-pointer select-none hover:text-slate-900 dark:hover:text-white transition-colors' : ''
+    }`
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Investment Funds</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+
+        {/* Toolbar */}
+        <div className="flex items-center justify-between gap-4 mb-6 flex-wrap">
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search by fund name…"
+            className="input-field w-full max-w-sm text-sm"
+          />
+          {isSupervisor && (
+            <button
+              onClick={() => navigate('/investment/funds/new')}
+              className="btn-primary text-xs px-5 py-2 shrink-0"
+            >
+              + Create Fund
+            </button>
+          )}
+        </div>
+
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-slate-500 dark:text-slate-400 text-sm">Loading funds…</p>
+            </div>
+          ) : error ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-red-500 text-sm">Failed to load funds.</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    <th className={thClass(false)}>Fund Name</th>
+                    <th className={thClass(false)}>Description</th>
+                    <th className={thClass(true)} onClick={() => handleSort('fundValue')}>
+                      Fund Value<SortIcon col="fundValue" />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('profit')}>
+                      Profit<SortIcon col="profit" />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('minimumContribution')}>
+                      Min. Contribution<SortIcon col="minimumContribution" />
+                    </th>
+                    {(isAgent || isSupervisor) && (
+                      <th className={thClass(false)}>Actions</th>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                        No funds found.
+                      </td>
+                    </tr>
+                  ) : (
+                    sorted.map((fund, i) => (
+                      <tr
+                        key={fund.id}
+                        className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                          i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
+                        }`}
+                      >
+                        <td className="px-4 py-3">
+                          <button
+                            onClick={() => navigate(`/investment/funds/${fund.id}`)}
+                            className="text-violet-600 dark:text-violet-400 hover:underline font-medium text-left"
+                          >
+                            {fund.name}
+                          </button>
+                        </td>
+                        <td className="px-4 py-3 text-slate-500 dark:text-slate-400 max-w-xs">
+                          {truncate(fund.description)}
+                        </td>
+                        <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">
+                          {fmt(fund.fundValue, 'RSD')}
+                        </td>
+                        <td className={`px-4 py-3 font-medium tabular-nums ${
+                          (fund.profit ?? 0) >= 0
+                            ? 'text-emerald-600 dark:text-emerald-400'
+                            : 'text-red-500 dark:text-red-400'
+                        }`}>
+                          {(fund.profit ?? 0) >= 0 ? '+' : ''}{fmt(fund.profit ?? 0, 'RSD')}
+                        </td>
+                        <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">
+                          {fmt(fund.minimumContribution, 'RSD')}
+                        </td>
+                        {(isAgent || isSupervisor) && (
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              {isAgent && (
+                                <button
+                                  onClick={() => setInvestModal(fund)}
+                                  className="btn-primary text-xs px-3 py-1"
+                                >
+                                  Invest
+                                </button>
+                              )}
+                              {isSupervisor && (
+                                <button
+                                  onClick={() => setDepositModal(fund)}
+                                  className="text-xs px-3 py-1 border border-violet-600 dark:border-violet-400 text-violet-600 dark:text-violet-400 hover:bg-violet-600 dark:hover:bg-violet-500 hover:text-white transition-all duration-200"
+                                >
+                                  Deposit
+                                </button>
+                              )}
+                            </div>
+                          </td>
+                        )}
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {!loading && !error && sorted.length > 0 && (
+            <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+              {sorted.length} fund{sorted.length !== 1 ? 's' : ''}
+            </div>
+          )}
+        </div>
+
+      </div>
+
+      {investModal && (
+        <InvestModal
+          fund={investModal}
+          onClose={() => setInvestModal(null)}
+          onSuccess={() => { setInvestModal(null); loadFunds() }}
+        />
+      )}
+      {depositModal && (
+        <BankDepositModal
+          fund={depositModal}
+          onClose={() => setDepositModal(null)}
+          onSuccess={() => { setDepositModal(null); loadFunds() }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/pages/otc/OtcContractsPage.jsx
+++ b/src/pages/otc/OtcContractsPage.jsx
@@ -1,0 +1,15 @@
+import useWindowTitle from '../../hooks/useWindowTitle'
+
+export default function OtcContractsPage() {
+  useWindowTitle('OTC Contracts | AnkaBanka')
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">OTC Contracts</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+        <p className="text-slate-500 dark:text-slate-400 text-sm">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/otc/OtcMarketPage.jsx
+++ b/src/pages/otc/OtcMarketPage.jsx
@@ -1,0 +1,15 @@
+import useWindowTitle from '../../hooks/useWindowTitle'
+
+export default function OtcMarketPage() {
+  useWindowTitle('OTC Market | AnkaBanka')
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">OTC Market</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+        <p className="text-slate-500 dark:text-slate-400 text-sm">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/otc/OtcNegotiationDetailPage.jsx
+++ b/src/pages/otc/OtcNegotiationDetailPage.jsx
@@ -1,0 +1,15 @@
+import useWindowTitle from '../../hooks/useWindowTitle'
+
+export default function OtcNegotiationDetailPage() {
+  useWindowTitle('Negotiation Detail | AnkaBanka')
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Negotiation Detail</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+        <p className="text-slate-500 dark:text-slate-400 text-sm">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/otc/OtcNegotiationsPage.jsx
+++ b/src/pages/otc/OtcNegotiationsPage.jsx
@@ -1,0 +1,218 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { useAuth } from '../../context/AuthContext'
+import { otcService } from '../../services/otcService'
+import { securitiesService } from '../../services/securitiesService'
+import { fmt } from '../../utils/formatting'
+
+const SORT_COLS = ['pricePerStock', 'settlementDate', 'lastModified']
+
+function getPriceColor(price, market) {
+  if (!market) return 'text-slate-700 dark:text-slate-300'
+  const dev = Math.abs((price - market) / market) * 100
+  if (dev <= 5)  return 'text-emerald-600 dark:text-emerald-400'
+  if (dev <= 20) return 'text-amber-500 dark:text-amber-400'
+  return 'text-red-500 dark:text-red-400'
+}
+
+function getStatusLabel(neg, userId) {
+  const myTurn =
+    (neg.status === 'PENDING_SELLER' && neg.sellerId === userId) ||
+    (neg.status === 'PENDING_BUYER'  && neg.buyerId  === userId)
+  return myTurn ? 'Your turn' : 'Waiting for the other party'
+}
+
+export default function OtcNegotiationsPage() {
+  useWindowTitle('OTC Negotiations | AnkaBanka')
+  const { user } = useAuth()
+  const navigate  = useNavigate()
+
+  const [negotiations, setNegotiations] = useState([])
+  const [loading, setLoading]           = useState(true)
+  const [error, setError]               = useState(null)
+  const [sortCol, setSortCol]           = useState(null)
+  const [sortOrder, setSortOrder]       = useState('ASC')
+  const [marketPrices, setMarketPrices] = useState({})
+
+  const loadNegotiations = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await otcService.getNegotiations()
+      const list = Array.isArray(data) ? data : (data.negotiations ?? data.items ?? [])
+      setNegotiations(list)
+      fetchMarketPrices(list)
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  async function fetchMarketPrices(list) {
+    const tickers = [...new Set(list.map(n => n.ticker).filter(Boolean))]
+    const results = await Promise.allSettled(
+      tickers.map(ticker => securitiesService.getListings({ ticker }))
+    )
+    const prices = {}
+    results.forEach((r, i) => {
+      if (r.status === 'fulfilled') {
+        const items = r.value?.items ?? r.value ?? []
+        const first = Array.isArray(items) ? items[0] : null
+        if (first?.price != null) prices[tickers[i]] = first.price
+      }
+    })
+    setMarketPrices(prices)
+  }
+
+  useEffect(() => { loadNegotiations() }, [loadNegotiations])
+
+  function handleSort(col) {
+    if (sortCol === col) {
+      setSortOrder(o => o === 'ASC' ? 'DESC' : 'ASC')
+    } else {
+      setSortCol(col)
+      setSortOrder('ASC')
+    }
+  }
+
+  function SortIcon({ col }) {
+    if (sortCol !== col) return <span className="text-slate-300 dark:text-slate-600 ml-1">↕</span>
+    return <span className="text-violet-500 ml-1">{sortOrder === 'ASC' ? '↑' : '↓'}</span>
+  }
+
+  const sorted = [...negotiations].sort((a, b) => {
+    if (!sortCol) return 0
+    const va = a[sortCol]
+    const vb = b[sortCol]
+    if (va == null && vb == null) return 0
+    if (va == null) return 1
+    if (vb == null) return -1
+    const cmp = typeof va === 'string' ? va.localeCompare(vb) : va - vb
+    return sortOrder === 'ASC' ? cmp : -cmp
+  })
+
+  const userId = user?.id
+
+  function thClass(sortable) {
+    return `px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap${
+      sortable ? ' cursor-pointer select-none hover:text-slate-900 dark:hover:text-white transition-colors' : ''
+    }`
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Employee Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">OTC Negotiations</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-slate-500 dark:text-slate-400 text-sm">Loading negotiations…</p>
+            </div>
+          ) : error ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-red-500 text-sm">Failed to load negotiations.</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    <th className={thClass(false)}>Ticker</th>
+                    <th className={thClass(false)}>Amount</th>
+                    <th className={thClass(true)} onClick={() => handleSort('pricePerStock')}>
+                      Price / Share<SortIcon col="pricePerStock" />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('settlementDate')}>
+                      Settlement Date<SortIcon col="settlementDate" />
+                    </th>
+                    <th className={thClass(false)}>Premium</th>
+                    <th className={thClass(true)} onClick={() => handleSort('lastModified')}>
+                      Last Modified<SortIcon col="lastModified" />
+                    </th>
+                    <th className={thClass(false)}>Status</th>
+                    <th className={thClass(false)} />
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                        You have no active negotiations.
+                      </td>
+                    </tr>
+                  ) : (
+                    sorted.map((neg, i) => {
+                      const marketPrice = marketPrices[neg.ticker]
+                      const priceColor  = getPriceColor(neg.pricePerStock, marketPrice)
+                      const statusLabel = getStatusLabel(neg, userId)
+                      const isMyTurn    = statusLabel === 'Your turn'
+                      return (
+                        <tr
+                          key={neg.id}
+                          className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${
+                            i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'
+                          }`}
+                        >
+                          <td className="px-4 py-3 font-mono font-medium text-slate-800 dark:text-slate-200">
+                            {neg.ticker}
+                          </td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">
+                            {neg.amount}
+                          </td>
+                          <td className={`px-4 py-3 font-medium tabular-nums ${priceColor}`}>
+                            {fmt(neg.pricePerStock)}
+                          </td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300">
+                            {neg.settlementDate ?? '—'}
+                          </td>
+                          <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">
+                            {fmt(neg.premium)}
+                          </td>
+                          <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs">
+                            <div>{neg.lastModified ? new Date(neg.lastModified).toLocaleString() : '—'}</div>
+                            {neg.modifiedByName && (
+                              <div className="text-slate-400 dark:text-slate-500">{neg.modifiedByName}</div>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className={`text-xs font-medium ${
+                              isMyTurn
+                                ? 'text-violet-600 dark:text-violet-400'
+                                : 'text-slate-400 dark:text-slate-500'
+                            }`}>
+                              {statusLabel}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <button
+                              onClick={() => navigate(`/otc/negotiations/${neg.id}`)}
+                              className="btn-primary text-xs px-3 py-1"
+                            >
+                              Open
+                            </button>
+                          </td>
+                        </tr>
+                      )
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {!loading && !error && sorted.length > 0 && (
+            <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+              {sorted.length} negotiation{sorted.length !== 1 ? 's' : ''}
+            </div>
+          )}
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/services/fundService.js
+++ b/src/services/fundService.js
@@ -1,0 +1,35 @@
+import { apiClient } from './apiClient'
+
+export const fundService = {
+  async getFunds() {
+    const { data } = await apiClient.get('/investment/funds')
+    return data
+  },
+
+  async getFund(id) {
+    const { data } = await apiClient.get(`/investment/funds/${id}`)
+    return data
+  },
+
+  async createFund(payload) {
+    const { data } = await apiClient.post('/investment/funds', payload)
+    return data
+  },
+
+  async updateFund(id, payload) {
+    const { data } = await apiClient.put(`/investment/funds/${id}`, payload)
+    return data
+  },
+
+  async deleteFund(id) {
+    await apiClient.delete(`/investment/funds/${id}`)
+  },
+
+  async invest(fundId, { sourceAccountId, amount }) {
+    const { data } = await apiClient.post(`/investment/funds/${fundId}/invest`, {
+      sourceAccountId,
+      amount,
+    })
+    return data
+  },
+}

--- a/src/services/otcService.js
+++ b/src/services/otcService.js
@@ -1,0 +1,33 @@
+import { apiClient } from './apiClient'
+
+export const otcService = {
+  async getNegotiations() {
+    const { data } = await apiClient.get('/otc/negotiations')
+    return data
+  },
+
+  async getNegotiation(id) {
+    const { data } = await apiClient.get(`/otc/negotiations/${id}`)
+    return data
+  },
+
+  async createNegotiation(payload) {
+    const { data } = await apiClient.post('/otc/negotiations', payload)
+    return data
+  },
+
+  async counterOffer(id, payload) {
+    const { data } = await apiClient.put(`/otc/negotiations/${id}/counter`, payload)
+    return data
+  },
+
+  async acceptNegotiation(id) {
+    const { data } = await apiClient.put(`/otc/negotiations/${id}/accept`)
+    return data
+  },
+
+  async rejectNegotiation(id) {
+    const { data } = await apiClient.put(`/otc/negotiations/${id}/reject`)
+    return data
+  },
+}


### PR DESCRIPTION
## Summary
- Add routes and nav links for OTC Trading and Investment Funds portals
- OtcNegotiationsPage: table with color-coded price deviation and turn-based status
- FundsDiscoveryPage: table with search, sort, role-based Invest/Deposit modals
- Implement CreateFundPage: full form with name, description, minimum contribution, and manager dropdown (populated from actuaries)
- Stub pages for OtcMarket, OtcNegotiationDetail, OtcContracts, FundDetail
- otcService and fundService wiring all backend endpoints

Closes #183, #184, #185, #187

## Test plan
- [ ] Log in as supervisor → navigate to Investment Funds → Create Fund form renders
- [ ] Fill form and submit → redirected to funds list, new fund appears
- [ ] Submit empty form → inline validation errors shown
- [ ] Non-supervisor visits `/investment/funds/new` → redirected to funds list
- [ ] OTC Negotiations page renders with correct columns and status colors
- [ ] Investment Funds discovery page renders with search/sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)