### PR TITLE
fix: fund deposit/withdraw modal account loading and error messages

### DIFF
--- a/src/pages/investment/FundDetailPage.jsx
+++ b/src/pages/investment/FundDetailPage.jsx
@@ -85,10 +85,11 @@ function BankDepositModal({ fund, onClose, onSuccess }) {
   const [bankAccountId, setBankAccountId]     = useState('')
   const [accounts, setAccounts]               = useState([])
   const [accountsLoading, setAccountsLoading] = useState(true)
+  const [amountError, setAmountError]         = useState('')
   const [submitting, setSubmitting]           = useState(false)
 
   useEffect(() => {
-    accountService.getAccounts()
+    accountService.getBankAccounts()
       .then(list => {
         const rsd = list.filter(a => a.currencyCode === 'RSD')
         setAccounts(rsd)
@@ -99,10 +100,13 @@ function BankDepositModal({ fund, onClose, onSuccess }) {
   }, [])
 
   async function handleSubmit() {
-    if (!amount || Number(amount) <= 0) return
+    const n = Number(amount)
+    if (!amount || isNaN(n) || n <= 0) { setAmountError('Please enter a valid amount.'); return }
+    if (n < fund.minimumContribution) { setAmountError(`Minimum contribution is ${fmt(fund.minimumContribution, 'RSD')}.`); return }
+    setAmountError('')
     setSubmitting(true)
     try {
-      await fundService.invest(fund.id, { sourceAccountId: Number(bankAccountId), amount: Number(amount) })
+      await fundService.invest(fund.id, { sourceAccountId: Number(bankAccountId), amount: n })
       onSuccess()
     } finally {
       setSubmitting(false)
@@ -121,8 +125,9 @@ function BankDepositModal({ fund, onClose, onSuccess }) {
         </div>
         <div className="px-6 py-5 flex flex-col gap-4">
           <div>
-            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Amount (RSD)</label>
-            <input type="number" value={amount} onChange={e => setAmount(e.target.value)} placeholder="0.00" className="input-field w-full text-sm" />
+            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Amount (RSD) — minimum {fmt(fund.minimumContribution, 'RSD')}</label>
+            <input type="number" value={amount} onChange={e => { setAmount(e.target.value); setAmountError('') }} placeholder={`${fund.minimumContribution}`} className={`input-field w-full text-sm${amountError ? ' input-error' : ''}`} />
+            {amountError && <p className="text-xs text-red-500 mt-1">{amountError}</p>}
           </div>
           <div>
             <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Bank Account (RSD)</label>
@@ -153,7 +158,8 @@ function WithdrawModal({ fund, isSupervisor, onClose, onSuccess }) {
   const [submitting, setSubmitting]                 = useState(false)
 
   useEffect(() => {
-    accountService.getAccounts()
+    const fetch = isSupervisor ? accountService.getBankAccounts() : accountService.getAccounts()
+    fetch
       .then(list => {
         const filtered = isSupervisor ? list.filter(a => a.currencyCode === 'RSD') : list
         setAccounts(filtered)

--- a/src/pages/investment/FundsDiscoveryPage.jsx
+++ b/src/pages/investment/FundsDiscoveryPage.jsx
@@ -144,10 +144,11 @@ function BankDepositModal({ fund, onClose, onSuccess }) {
   const [bankAccountId, setBankAccountId] = useState('')
   const [accounts, setAccounts]       = useState([])
   const [accountsLoading, setAccountsLoading] = useState(true)
+  const [amountError, setAmountError] = useState('')
   const [submitting, setSubmitting]   = useState(false)
 
   useEffect(() => {
-    accountService.getAccounts()
+    accountService.getBankAccounts()
       .then(list => {
         const rsd = list.filter(a => a.currencyCode === 'RSD')
         setAccounts(rsd)
@@ -158,11 +159,13 @@ function BankDepositModal({ fund, onClose, onSuccess }) {
   }, [])
 
   async function handleSubmit() {
-    if (!amount || Number(amount) <= 0) return
+    const n = Number(amount)
+    if (!amount || isNaN(n) || n <= 0) { setAmountError('Please enter a valid amount.'); return }
+    if (n < fund.minimumContribution) { setAmountError(`Minimum contribution is ${fmt(fund.minimumContribution, 'RSD')}.`); return }
+    setAmountError('')
     setSubmitting(true)
     try {
-      // POST /investment/funds/:id/invest (bank deposit uses same endpoint with bank account)
-      await fundService.invest(fund.id, { sourceAccountId: Number(bankAccountId), amount: Number(amount) })
+      await fundService.invest(fund.id, { sourceAccountId: Number(bankAccountId), amount: n })
       onSuccess()
     } finally {
       setSubmitting(false)
@@ -193,14 +196,17 @@ function BankDepositModal({ fund, onClose, onSuccess }) {
 
         <div className="px-6 py-5 flex flex-col gap-4">
           <div>
-            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Amount (RSD)</label>
+            <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">
+              Amount (RSD) — minimum {fmt(fund.minimumContribution, 'RSD')}
+            </label>
             <input
               type="number"
               value={amount}
-              onChange={e => setAmount(e.target.value)}
-              placeholder="0.00"
-              className="input-field w-full text-sm"
+              onChange={e => { setAmount(e.target.value); setAmountError('') }}
+              placeholder={`${fund.minimumContribution}`}
+              className={`input-field w-full text-sm${amountError ? ' input-error' : ''}`}
             />
+            {amountError && <p className="text-xs text-red-500 mt-1">{amountError}</p>}
           </div>
 
           <div>

--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -45,4 +45,9 @@ export const accountService = {
   async deleteAccount(id) {
     await apiClient.delete(`/api/accounts/${id}`)
   },
+
+  async getBankAccounts() {
+    const { data } = await apiClient.get('/api/bank-accounts')
+    return data
+  },
 }

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -71,7 +71,8 @@ apiClient.interceptors.response.use(
 
     // Dispatch user-friendly error notifications for non-401 errors.
     if (status && status !== 401) {
-      const message = API_ERROR_MESSAGES[status] ?? 'An unexpected error occurred.'
+      const backendMessage = error.response?.data?.error
+      const message = backendMessage || API_ERROR_MESSAGES[status] || 'An unexpected error occurred.'
       dispatchApiError(status, message)
     }
 


### PR DESCRIPTION
## Summary
- `BankDepositModal` now loads bank accounts via `GET /api/bank-accounts` instead of client accounts
- `WithdrawModal` (supervisor path) also loads bank accounts instead of client accounts
- Added minimum contribution validation to `BankDepositModal` (was missing, caused 400 errors)
- Toast notifications now show the actual backend error message instead of a generic string

## Test plan
- [ ] Supervisor → Deposit modal → shows bank RSD accounts only (no client accounts, no fund accounts)
- [ ] Supervisor → Withdraw modal → same
- [ ] Deposit below minimum contribution → inline error shown, no request sent
- [ ] Failed invest/withdraw → toast shows specific error (e.g. "insufficient account balance")

🤖 Generated with [Claude Code](https://claude.com/claude-code)