### PR TITLE
fix: OTC UX improvements, date formatting, portfolio and fund fixes

### DIFF
--- a/src/pages/client/ClientHomePage.jsx
+++ b/src/pages/client/ClientHomePage.jsx
@@ -6,7 +6,7 @@ import { useClientAuth } from '../../context/ClientAuthContext'
 import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { useClientPayments } from '../../context/ClientPaymentsContext'
 import { NAV_ITEMS } from '../../layouts/ClientPortalLayout'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDate } from '../../utils/formatting'
 import { useRecipients } from '../../context/RecipientsContext'
 import { exchangeService } from '../../services/exchangeService'
 
@@ -398,7 +398,7 @@ export default function ClientHomePage() {
                               const otherParty = isOutgoing ? (p.recipient || p.recipientAccount) : p.fromAccount
                               return <>
                                 <p className="text-sm text-slate-700 dark:text-slate-300 font-light truncate">{p.purpose || otherParty}</p>
-                                <p className="text-xs text-slate-400 dark:text-slate-500">{new Date(p.dateTime).toLocaleDateString('sr-RS')}</p>
+                                <p className="text-xs text-slate-400 dark:text-slate-500">{fmtDate(p.dateTime)}</p>
                               </>
                             })()}
                           </div>

--- a/src/pages/client/ClientOtcContractsPage.jsx
+++ b/src/pages/client/ClientOtcContractsPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { clientOtcService } from '../../services/clientOtcService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDate } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 
 const TABS = [
@@ -190,7 +190,7 @@ export default function ClientOtcContractsPage() {
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{c.amount}</td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{fmt(c.strikePrice)}</td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{fmt(c.premium)}</td>
-                        <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">{c.settlementDate ?? '—'}</td>
+                        <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">{fmtDate(c.settlementDate)}</td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 text-xs">
                           <div>{c.sellerName ?? '—'}</div>
                         </td>

--- a/src/pages/client/ClientOtcMarketPage.jsx
+++ b/src/pages/client/ClientOtcMarketPage.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { clientOtcService } from '../../services/clientOtcService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDateTime } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 
 function OfferModal({ item, onClose, onSubmit }) {
@@ -32,8 +33,8 @@ function OfferModal({ item, onClose, onSubmit }) {
         currency:       item.currency,
       })
       onClose()
-    } catch {
-      setError('Failed to submit offer. Please try again.')
+    } catch (err) {
+      setError(err?.response?.data?.error || 'Failed to submit offer. Please try again.')
     } finally {
       setSubmitting(false)
     }
@@ -107,6 +108,7 @@ function OfferModal({ item, onClose, onSubmit }) {
             <input
               type="date"
               value={settlementDate}
+              min={new Date(Date.now() + 86400000).toISOString().slice(0, 10)}
               onChange={e => setSettlementDate(e.target.value)}
               className="input-field w-full"
             />
@@ -138,6 +140,7 @@ function OfferModal({ item, onClose, onSubmit }) {
 
 export default function ClientOtcMarketPage() {
   useWindowTitle('OTC Market | AnkaBanka')
+  const navigate = useNavigate()
 
   const [items,      setItems]      = useState([])
   const [loading,    setLoading]    = useState(true)
@@ -155,6 +158,7 @@ export default function ClientOtcMarketPage() {
 
   async function handleOffer(payload) {
     await clientOtcService.createNegotiation(payload)
+    navigate('/client/otc/negotiations')
   }
 
   function thClass() {
@@ -219,7 +223,7 @@ export default function ClientOtcMarketPage() {
                           {fmt(item.pricePerStock)} {item.currency && <span className="text-xs text-slate-400">{item.currency}</span>}
                         </td>
                         <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">
-                          {item.lastUpdated ? new Date(item.lastUpdated).toLocaleString() : '—'}
+                          {fmtDateTime(item.lastUpdated)}
                         </td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 text-xs">
                           <div>{item.ownerName ?? '—'}</div>

--- a/src/pages/client/ClientOtcNegotiationDetailPage.jsx
+++ b/src/pages/client/ClientOtcNegotiationDetailPage.jsx
@@ -4,7 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClientAuth } from '../../context/ClientAuthContext'
 import { clientOtcService } from '../../services/clientOtcService'
 import { clientSecuritiesService } from '../../services/clientSecuritiesService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDate, fmtDateTime } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 
 function getPriceColor(price, market) {
@@ -69,14 +69,20 @@ export default function ClientOtcNegotiationDetailPage() {
     ((neg.status === 'PENDING_SELLER' && neg.sellerId === userId) ||
      (neg.status === 'PENDING_BUYER'  && neg.buyerId  === userId))
 
+  const [accepted, setAccepted] = useState(false)
+
+  function apiError(err, fallback) {
+    return err?.response?.data?.error || fallback
+  }
+
   async function handleAccept() {
     setActing(true)
     setActionError(null)
     try {
       await clientOtcService.acceptNegotiation(id)
-      navigate('/client/otc/negotiations')
-    } catch {
-      setActionError('Failed to accept negotiation.')
+      setAccepted(true)
+    } catch (err) {
+      setActionError(apiError(err, 'Failed to accept negotiation.'))
     } finally {
       setActing(false)
       setShowAcceptConfirm(false)
@@ -89,8 +95,8 @@ export default function ClientOtcNegotiationDetailPage() {
     try {
       await clientOtcService.rejectNegotiation(id)
       navigate('/client/otc/negotiations')
-    } catch {
-      setActionError('Failed to reject negotiation.')
+    } catch (err) {
+      setActionError(apiError(err, 'Failed to reject negotiation.'))
     } finally {
       setActing(false)
     }
@@ -112,8 +118,8 @@ export default function ClientOtcNegotiationDetailPage() {
         premium:        counterPremium ? Number(counterPremium) : 0,
       })
       navigate('/client/otc/negotiations')
-    } catch {
-      setActionError('Failed to submit counter-offer.')
+    } catch (err) {
+      setActionError(apiError(err, 'Failed to submit counter-offer.'))
     } finally {
       setActing(false)
     }
@@ -134,6 +140,30 @@ export default function ClientOtcNegotiationDetailPage() {
         <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Client Portal</p>
         <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-3">Negotiation Detail</h1>
         <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
+
+        {accepted && neg && (
+          <div className="bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700 rounded-xl p-6 mb-6">
+            <p className="text-emerald-700 dark:text-emerald-300 font-medium text-sm mb-1">Negotiation accepted.</p>
+            {neg.buyerId === userId ? (
+              <>
+                <p className="text-emerald-600 dark:text-emerald-400 text-sm mb-3">
+                  A contract has been created. You need to <strong>exercise</strong> it to receive the shares —
+                  go to <strong>OTC Contracts</strong> and click Exercise before the settlement date ({fmtDate(neg.settlementDate)}).
+                </p>
+                <button
+                  onClick={() => navigate('/client/otc/contracts')}
+                  className="btn-primary text-sm px-4 py-2"
+                >
+                  Go to OTC Contracts
+                </button>
+              </>
+            ) : (
+              <p className="text-emerald-600 dark:text-emerald-400 text-sm">
+                Waiting for the buyer to exercise the contract before the settlement date ({fmtDate(neg.settlementDate)}).
+              </p>
+            )}
+          </div>
+        )}
 
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400 text-sm">Loading…</p>
@@ -167,11 +197,11 @@ export default function ClientOtcNegotiationDetailPage() {
                 </Field>
 
                 <Field label="Settlement Date">
-                  {neg.settlementDate ?? '—'}
+                  {fmtDate(neg.settlementDate)}
                 </Field>
 
                 <Field label="Last Modified">
-                  <div>{neg.lastModified ? new Date(neg.lastModified).toLocaleString() : '—'}</div>
+                  <div>{fmtDateTime(neg.lastModified)}</div>
                   {neg.modifiedByName && (
                     <div className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{neg.modifiedByName}</div>
                   )}
@@ -189,7 +219,7 @@ export default function ClientOtcNegotiationDetailPage() {
               </div>
             </div>
 
-            {isMyTurn && (
+            {isMyTurn && !accepted && (
               <div className="space-y-4">
                 {actionError && (
                   <p className="text-red-500 text-xs">{actionError}</p>
@@ -278,6 +308,7 @@ export default function ClientOtcNegotiationDetailPage() {
                           <input
                             type="date"
                             value={counterDate}
+                            min={new Date(Date.now() + 86400000).toISOString().slice(0, 10)}
                             onChange={e => setCounterDate(e.target.value)}
                             className="input-field w-full"
                           />

--- a/src/pages/client/ClientOtcNegotiationsPage.jsx
+++ b/src/pages/client/ClientOtcNegotiationsPage.jsx
@@ -4,7 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClientAuth } from '../../context/ClientAuthContext'
 import { clientOtcService } from '../../services/clientOtcService'
 import { clientSecuritiesService } from '../../services/clientSecuritiesService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDate, fmtDateTime } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 
 const SORT_COLS = ['pricePerStock', 'settlementDate', 'lastModified']
@@ -169,13 +169,13 @@ export default function ClientOtcNegotiationsPage() {
                             {fmt(neg.pricePerStock)}
                           </td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300">
-                            {neg.settlementDate ?? '—'}
+                            {fmtDate(neg.settlementDate)}
                           </td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">
                             {fmt(neg.premium)}
                           </td>
                           <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs">
-                            <div>{neg.lastModified ? new Date(neg.lastModified).toLocaleString() : '—'}</div>
+                            <div>{fmtDateTime(neg.lastModified)}</div>
                             {neg.modifiedByName && (
                               <div className="text-slate-400 dark:text-slate-500">{neg.modifiedByName}</div>
                             )}

--- a/src/pages/client/ClientPaymentsPage.jsx
+++ b/src/pages/client/ClientPaymentsPage.jsx
@@ -5,7 +5,7 @@ import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useClientPayments } from '../../context/ClientPaymentsContext'
 import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { PAYMENT_STATUSES, PAYMENT_STATUS_STYLES } from '../../models/Payment'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDateTime } from '../../utils/formatting'
 import Spinner from '../../components/Spinner'
 
 const STATUS_OPTIONS = ['all', ...PAYMENT_STATUSES]
@@ -160,7 +160,7 @@ export default function ClientPaymentsPage() {
                       const otherParty = isOutgoing ? (p.recipient || p.recipientAccount) : p.fromAccount
                       const label = p.purpose || otherParty
                       return <>
-                        <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light whitespace-nowrap">{new Date(p.dateTime).toLocaleString('sr-RS')}</td>
+                        <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light whitespace-nowrap">{fmtDateTime(p.dateTime)}</td>
                         <td className="px-5 py-3.5 text-sm text-slate-900 dark:text-white font-light">{label}</td>
                         <td className={`px-5 py-3.5 text-sm font-medium text-right whitespace-nowrap ${isOutgoing ? 'text-red-500 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'}`}>
                           {isOutgoing ? '-' : '+'}{fmt(Math.abs(p.amount))}

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -238,7 +238,7 @@ export default function ClientPortfolioPage() {
   }, [activeTab.key, loadMyFunds])
 
   const displayed = activeTab.key === 'public'
-    ? holdings.filter(h => h.isPublic)
+    ? holdings.filter(h => h.is_public)
     : holdings
 
   return (

--- a/src/pages/client/ClientTransfersPage.jsx
+++ b/src/pages/client/ClientTransfersPage.jsx
@@ -4,7 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { useClientAccounts } from '../../context/ClientAccountsContext'
 import { transferService } from '../../services/transferService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDateTime } from '../../utils/formatting'
 import { useApiError } from '../../context/ApiErrorContext'
 
 const EMPTY_FORM = {
@@ -305,7 +305,7 @@ export default function ClientTransfersPage() {
                       className={`${i !== history.length - 1 ? 'border-b border-slate-100 dark:border-slate-800' : ''}`}
                     >
                       <td className="px-5 py-3.5 text-sm text-slate-500 dark:text-slate-400 font-light whitespace-nowrap">
-                        {new Date(t.timestamp).toLocaleString('sr-RS')}
+                        {fmtDateTime(t.timestamp)}
                       </td>
                       <td className="px-5 py-3.5 text-sm text-slate-700 dark:text-slate-300 font-light">{accountNameByNumber(t.fromAccount)}</td>
                       <td className="px-5 py-3.5 text-sm text-slate-700 dark:text-slate-300 font-light">{accountNameByNumber(t.toAccount)}</td>

--- a/src/pages/employee/AccountDetailPage.jsx
+++ b/src/pages/employee/AccountDetailPage.jsx
@@ -6,7 +6,7 @@ import { accountService } from '../../services/accountService'
 import { employeeCardService } from '../../services/cardService'
 import { BankAccount, formatAccountType } from '../../models/BankAccount'
 import { Card as CardModel } from '../../models/Card'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDate } from '../../utils/formatting'
 import Spinner from '../../components/Spinner'
 import CardBrand from '../../components/CardBrand'
 import CardDetailModal from '../../components/CardDetailModal'
@@ -210,8 +210,8 @@ export default function AccountDetailPage() {
           {account.maintenanceFee > 0 && (
             <Row label="Maintenance Fee" value={fmt(account.maintenanceFee, account.currency) + ' / month'} />
           )}
-          {account.createdAt && <Row label="Created"  value={new Date(account.createdAt).toLocaleDateString('sr-RS')} />}
-          {account.expiresAt && <Row label="Expires"  value={new Date(account.expiresAt).toLocaleDateString('sr-RS')} />}
+          {account.createdAt && <Row label="Created"  value={fmtDate(account.createdAt)} />}
+          {account.expiresAt && <Row label="Expires"  value={fmtDate(account.expiresAt)} />}
         </Card>
 
         {/* Balance */}

--- a/src/pages/investment/CreateFundPage.jsx
+++ b/src/pages/investment/CreateFundPage.jsx
@@ -10,7 +10,7 @@ export default function CreateFundPage() {
   const { user } = useAuth()
   const navigate = useNavigate()
 
-  const [actuaries, setActuaries] = useState([])
+  const [supervisors, setSupervisors] = useState([])
   const [form, setForm] = useState({ name: '', description: '', minimumContribution: '', managerId: '' })
   const [errors, setErrors] = useState({})
   const [submitting, setSubmitting] = useState(false)
@@ -22,7 +22,7 @@ export default function CreateFundPage() {
   }, [user, navigate])
 
   useEffect(() => {
-    actuaryService.getActuaries().then(setActuaries).catch(() => {})
+    actuaryService.getSupervisors().then(setSupervisors).catch(() => {})
   }, [])
 
   function handleChange(e) {
@@ -124,9 +124,9 @@ export default function CreateFundPage() {
               className={`input-field appearance-none ${errors.managerId ? 'input-error' : ''}`}
             >
               <option value="">Select a manager</option>
-              {actuaries.map((a) => (
-                <option key={a.employeeId} value={a.employeeId}>
-                  {a.fullName} — {a.position}
+              {supervisors.map((s) => (
+                <option key={s.employee_id} value={s.employee_id}>
+                  {s.first_name} {s.last_name} — {s.position}
                 </option>
               ))}
             </select>

--- a/src/pages/otc/OtcMarketPage.jsx
+++ b/src/pages/otc/OtcMarketPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { otcService } from '../../services/otcService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDateTime } from '../../utils/formatting'
 
 function OfferModal({ item, onClose, onSubmit }) {
   const [quantity,       setQuantity]       = useState('')
@@ -219,7 +219,7 @@ export default function OtcMarketPage() {
                           {fmt(item.pricePerStock)} {item.currency && <span className="text-xs text-slate-400">{item.currency}</span>}
                         </td>
                         <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">
-                          {item.lastUpdated ? new Date(item.lastUpdated).toLocaleString() : '—'}
+                          {fmtDateTime(item.lastUpdated)}
                         </td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 text-xs">
                           <div>{item.ownerName ?? '—'}</div>

--- a/src/pages/otc/OtcNegotiationDetailPage.jsx
+++ b/src/pages/otc/OtcNegotiationDetailPage.jsx
@@ -4,7 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
 import { otcService } from '../../services/otcService'
 import { securitiesService } from '../../services/securitiesService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDate, fmtDateTime } from '../../utils/formatting'
 
 function getPriceColor(price, market) {
   if (!market) return 'text-slate-700 dark:text-slate-300'
@@ -172,7 +172,7 @@ export default function OtcNegotiationDetailPage() {
                 </Field>
 
                 <Field label="Last Modified">
-                  <div>{neg.lastModified ? new Date(neg.lastModified).toLocaleString() : '—'}</div>
+                  <div>{fmtDateTime(neg.lastModified)}</div>
                   {neg.modifiedByName && (
                     <div className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{neg.modifiedByName}</div>
                   )}

--- a/src/pages/otc/OtcNegotiationsPage.jsx
+++ b/src/pages/otc/OtcNegotiationsPage.jsx
@@ -4,7 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
 import { otcService } from '../../services/otcService'
 import { securitiesService } from '../../services/securitiesService'
-import { fmt } from '../../utils/formatting'
+import { fmt, fmtDate, fmtDateTime } from '../../utils/formatting'
 
 const SORT_COLS = ['pricePerStock', 'settlementDate', 'lastModified']
 
@@ -175,7 +175,7 @@ export default function OtcNegotiationsPage() {
                             {fmt(neg.premium)}
                           </td>
                           <td className="px-4 py-3 text-slate-500 dark:text-slate-400 text-xs">
-                            <div>{neg.lastModified ? new Date(neg.lastModified).toLocaleString() : '—'}</div>
+                            <div>{fmtDateTime(neg.lastModified)}</div>
                             {neg.modifiedByName && (
                               <div className="text-slate-400 dark:text-slate-500">{neg.modifiedByName}</div>
                             )}

--- a/src/services/actuaryService.js
+++ b/src/services/actuaryService.js
@@ -3,6 +3,14 @@ import { actuaryInfoFromApi } from '../models/ActuaryInfo'
 
 export const actuaryService = {
   /**
+   * Fetch all active supervisors (for fund manager selection).
+   */
+  async getSupervisors() {
+    const { data } = await apiClient.get('/api/supervisors')
+    return data
+  },
+
+  /**
    * Fetch all agents with their actuary limit info.
    */
   async getActuaries() {

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,14 +1,21 @@
-/**
- * Format a number using the Serbian locale (e.g. 1.234,56).
- * Optionally append a currency code.
- *
- * @param {number} n
- * @param {string} [currency] - e.g. 'RSD', 'EUR'
- */
 export function fmt(n, currency) {
   const formatted = n.toLocaleString('sr-RS', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })
   return currency ? `${formatted} ${currency}` : formatted
+}
+
+export function fmtDate(value) {
+  if (!value) return '—'
+  const d = new Date(value)
+  if (isNaN(d)) return value
+  return d.toLocaleDateString('en-GB')
+}
+
+export function fmtDateTime(value) {
+  if (!value) return '—'
+  const d = new Date(value)
+  if (isNaN(d)) return value
+  return d.toLocaleDateString('en-GB') + ' ' + d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
 }


### PR DESCRIPTION
## Summary

- **OTC Negotiation detail**: real backend error messages shown instead of generic fallback; post-accept banner guides buyer to OTC Contracts or informs seller to wait; action buttons hidden after accept; settlement date input min = tomorrow
- **OTC Market**: navigate to negotiations list after submitting offer; real error messages; settlement date min = tomorrow
- **Portfolio**: fix Public Securities tab filter (`h.isPublic` → `h.is_public`)
- **Create Fund**: manager dropdown now calls `GET /api/supervisors` and lists supervisors only
- **Date formatting**: all dates use dd/mm/yyyy (en-GB) via new `fmtDate`/`fmtDateTime` helpers

## Test plan

- [ ] OTC Negotiation — accept shows green banner with correct guidance for buyer vs. seller
- [ ] OTC Negotiation — accept/reject/counter buttons hidden after accepting
- [ ] OTC Market — past settlement date not selectable
- [ ] Portfolio → Public Securities tab shows public stocks
- [ ] Create Fund → manager dropdown shows supervisors
- [ ] All date/time fields display in dd/mm/yyyy format

🤖 Generated with [Claude Code](https://claude.com/claude-code)