### PR TITLE
fix: Public Securities tab filter on employee PortfolioPage

### DIFF
--- a/src/pages/orders/PortfolioPage.jsx
+++ b/src/pages/orders/PortfolioPage.jsx
@@ -104,7 +104,7 @@ export default function PortfolioPage() {
   }, [activeTab.key, loadMyFunds])
 
   const displayed = activeTab.key === 'public'
-    ? holdings.filter(h => h.isPublic)
+    ? holdings.filter(h => h.is_public)
     : holdings
 
   return (


### PR DESCRIPTION
## Summary

- Fix `h.isPublic` → `h.is_public` in `PortfolioPage.jsx` (employee portal)
- Same bug as the client portal fix from PR #207 — the API returns `is_public` (snake_case) but the tab filter was checking `isPublic` (camelCase, always undefined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)