### PR TITLE
feat: Bank Profit Portal — actuary performances page and fund positio…

### DIFF
--- a/src/layouts/EmployeePortalLayout.jsx
+++ b/src/layouts/EmployeePortalLayout.jsx
@@ -55,8 +55,8 @@ export const NAV_ITEMS = [
   },
   {
     label: 'Bank Profit',
-    href: '/admin/bank-profit/fund-positions',
-    icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    href: '/admin/bank-profit/actuaries',
+    icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
     show: (p) => p?.isSupervisor,
   },
   {

--- a/src/pages/employee/BankProfitActuariesPage.jsx
+++ b/src/pages/employee/BankProfitActuariesPage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { NavLink, Navigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { usePermission } from '../../hooks/usePermission'
-import { actuaryService } from '../../services/actuaryService'
+import { bankProfitService } from '../../services/bankProfitService'
 import { fmt } from '../../utils/formatting'
 
 const POSITION_STYLES = {
@@ -21,15 +21,23 @@ export default function BankProfitActuariesPage() {
   const [loading,      setLoading]      = useState(true)
   const [error,        setError]        = useState(false)
   const [sortAsc,      setSortAsc]      = useState(false)
+  const [search,       setSearch]       = useState('')
 
   useEffect(() => {
-    actuaryService.getActuaryPerformances()
+    bankProfitService.getActuaryPerformances()
       .then(data => setPerformances(data))
       .catch(() => setError(true))
       .finally(() => setLoading(false))
   }, [])
 
-  const sorted = [...performances].sort((a, b) =>
+  const q = search.trim().toLowerCase()
+  const filtered = q
+    ? performances.filter(p =>
+        `${p.firstName} ${p.lastName}`.toLowerCase().includes(q)
+      )
+    : performances
+
+  const sorted = [...filtered].sort((a, b) =>
     sortAsc ? a.profit - b.profit : b.profit - a.profit
   )
 
@@ -57,6 +65,17 @@ export default function BankProfitActuariesPage() {
           <NavLink to="/admin/bank-profit/fund-positions" className={tabClass}>
             Fund Positions
           </NavLink>
+        </div>
+
+        {/* Search */}
+        <div className="mb-4">
+          <input
+            type="text"
+            className="input-field w-full max-w-sm"
+            placeholder="Search by name…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
         </div>
 
         {/* Table */}
@@ -88,7 +107,7 @@ export default function BankProfitActuariesPage() {
                   {sorted.length === 0 ? (
                     <tr>
                       <td colSpan={3} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
-                        No actuary performance data available.
+                        No actuaries found.
                       </td>
                     </tr>
                   ) : (
@@ -121,9 +140,11 @@ export default function BankProfitActuariesPage() {
               </table>
             </div>
           )}
-          {!loading && !error && sorted.length > 0 && (
+          {!loading && !error && performances.length > 0 && (
             <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
-              {sorted.length} actuar{sorted.length !== 1 ? 'ies' : 'y'}
+              {sorted.length === performances.length
+                ? `${performances.length} actuar${performances.length !== 1 ? 'ies' : 'y'}`
+                : `${sorted.length} of ${performances.length} actuaries`}
             </div>
           )}
         </div>

--- a/src/pages/employee/BankProfitFundPositionsPage.jsx
+++ b/src/pages/employee/BankProfitFundPositionsPage.jsx
@@ -3,6 +3,7 @@ import { Link, NavLink, Navigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { usePermission } from '../../hooks/usePermission'
 import { bankProfitService } from '../../services/bankProfitService'
+import { fundService } from '../../services/fundService'
 import { accountService } from '../../services/accountService'
 import { fmt } from '../../utils/formatting'
 
@@ -195,8 +196,25 @@ export default function BankProfitFundPositionsPage() {
     setLoading(true)
     setError(false)
     try {
-      const data = await bankProfitService.getBankFundPositions()
-      setPositions(data)
+      const [funds, bankPositions] = await Promise.all([
+        fundService.getFunds(),
+        bankProfitService.getBankFundPositions(),
+      ])
+      const posMap = new Map(bankPositions.map(p => [p.fundId, p]))
+      const rows = (Array.isArray(funds) ? funds : [])
+        .filter(f => f.active)
+        .map(f => {
+          const pos = posMap.get(f.id)
+          return {
+            fundId:           f.id,
+            fundName:         f.name,
+            managerName:      f.managerName ?? pos?.managerName ?? '—',
+            bankSharePercent: pos?.bankSharePercent ?? 0,
+            bankShareRSD:     pos?.bankShareRSD     ?? 0,
+            profitRSD:        pos?.profitRSD        ?? 0,
+          }
+        })
+      setPositions(rows)
     } catch {
       setError(true)
     } finally {

--- a/src/services/bankProfitService.js
+++ b/src/services/bankProfitService.js
@@ -1,18 +1,23 @@
 import { apiClient } from './apiClient'
 
 export const bankProfitService = {
+  async getActuaryPerformances() {
+    const { data } = await apiClient.get('/bank/profit/actuaries')
+    return Array.isArray(data) ? data : (data.actuaries ?? data.items ?? [])
+  },
+
   async getBankFundPositions() {
     const { data } = await apiClient.get('/bank/profit/fund-positions')
     return Array.isArray(data) ? data : (data.positions ?? data.items ?? [])
   },
 
   async bankInvest(fundId, { accountId, amount }) {
-    const { data } = await apiClient.post(`/bank/profit/fund-positions/${fundId}/invest`, { accountId, amount })
+    const { data } = await apiClient.post(`/bank/profit/fund-positions/${fundId}/invest`, { sourceAccountId: accountId, amount })
     return data
   },
 
   async bankRedeem(fundId, { accountId, amount }) {
-    const { data } = await apiClient.post(`/bank/profit/fund-positions/${fundId}/redeem`, { accountId, amount })
+    const { data } = await apiClient.post(`/bank/profit/fund-positions/${fundId}/redeem`, { destinationAccountId: accountId, amount })
     return data
   },
 }


### PR DESCRIPTION
…ns fix

- Add BankProfitActuariesPage: uses bankProfitService, adds client-side name search
- Fix BankProfitFundPositionsPage: show all active funds (not just those with bank positions) by merging fundService.getFunds() with bank positions, so supervisors can deposit into newly created funds
- Fix bankProfitService.bankInvest/bankRedeem: correct field names (sourceAccountId, destinationAccountId) to match backend binding
- Update EmployeePortalLayout: Bank Profit nav points to /actuaries with correct icon

Closes #202