### PR TITLE
fix(orders): pass purchaseFor field when buying stocks for a fund

### DIFF
--- a/src/pages/orders/CreateOrderPage.jsx
+++ b/src/pages/orders/CreateOrderPage.jsx
@@ -145,8 +145,9 @@ export default function CreateOrderPage() {
         stopValue:  stopValue  !== '' ? Number(stopValue)  : undefined,
         isAon,
         isMargin,
-        accountId:  Number(accountId),
-        fundId:     buyFor === 'fund' ? Number(fundId) : undefined,
+        accountId:   Number(accountId),
+        fundId:      buyFor === 'fund' ? Number(fundId) : undefined,
+        purchaseFor: buyFor === 'fund' ? 'FUND' : undefined,
       })
       setSubmitted(true)
       setShowConfirm(false)

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -5,7 +5,7 @@ export const orderService = {
   /**
    * Place a new order.
    */
-  async createOrder({ assetId, quantity, direction, limitValue, stopValue, isAon, isMargin, accountId, fundId }) {
+  async createOrder({ assetId, quantity, direction, limitValue, stopValue, isAon, isMargin, accountId, fundId, purchaseFor }) {
     const { data } = await apiClient.post('/orders', {
       assetId,
       quantity,
@@ -16,6 +16,7 @@ export const orderService = {
       isMargin,
       accountId,
       ...(fundId != null ? { fundId } : {}),
+      ...(purchaseFor ? { purchaseFor } : {}),
     })
     return data
   },


### PR DESCRIPTION
Without purchaseFor: 'FUND' in the order payload the api-gateway never entered the fund-validation block, so fundId stayed 0 and the order was booked against the employee's personal bank account instead of the fund account. Stocks ended up in the personal portfolio rather than the fund portfolio, and no liquidity check was run against the fund.

- orderService.createOrder: accept purchaseFor param and include it in the POST body when present (spread, omitted when undefined).
- CreateOrderPage: pass purchaseFor: 'FUND' and fundId when buyFor === 'fund', undefined otherwise, so personal and fund orders remain distinguishable end-to-end.