### PR TITLE
fix(tests): update seeded account number from 265 to 888 in accounts …

### DIFF
--- a/cypress/e2e/celina2/accounts.cy.js
+++ b/cypress/e2e/celina2/accounts.cy.js
@@ -40,7 +40,7 @@ describe('Kreiranje računa — zaposleni', () => {
           const stale = accounts.filter(a =>
             a.ownerId === TARA_OWNER_ID &&
             /^\d{18}$/.test(a.accountNumber) &&
-            a.accountNumber !== '265000100000000101'
+            a.accountNumber !== '888000100000000101'
           )
           stale.forEach(a => {
             cy.request({


### PR DESCRIPTION
…Cypress test

Related to RAF-SI-2025/EXBanka-4-Backend#248

The seeded Tara account number changed from 265000100000000101 to 888000100000000101 following the bank routing number correction. The accounts.cy.js cleanup step was comparing against the old number to preserve the seeded account — updated to match.