### PR TITLE
feat: add Kubernetes deploy job to frontend workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,3 +45,21 @@ jobs:
           build-args: |
             VITE_API_URL=${{ secrets.VITE_API_URL }}
           tags: ghcr.io/raf-si-2025/exbanka-4-frontend:${{ github.sha }}
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: docker
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy to Kubernetes
+        run: |
+          kubectl set image deployment/frontend frontend=ghcr.io/raf-si-2025/exbanka-4-frontend:${{ github.sha }} -n exbanka


### PR DESCRIPTION
## Summary

- Adds a `deploy` job to `.github/workflows/docker.yml` that runs after a successful image push
- Calls `kubectl set image deployment/frontend frontend=ghcr.io/raf-si-2025/exbanka-4-frontend:<sha> -n exbanka`
- Requires `KUBECONFIG` secret (base64-encoded kubeconfig) to be set in repo settings

## Test plan

- [ ] Add `KUBECONFIG` secret to repo settings once cluster is available
- [ ] Push any frontend change and verify the deploy job runs after the docker build job
- [ ] Confirm pod is updated: `kubectl get pods -n exbanka | grep frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)