### PR TITLE
feat(#218): show cross-bank fee/rate on payment verify page

### DIFF
--- a/src/pages/client/ClientPaymentVerifyPage.jsx
+++ b/src/pages/client/ClientPaymentVerifyPage.jsx
@@ -31,6 +31,8 @@ export default function ClientPaymentVerifyPage() {
   const [phase, setPhase] = useState('creating')
   const [errorMsg, setErrorMsg] = useState('')
   const pollRef = useRef(null)
+  const [preview, setPreview] = useState(null)
+  const [previewLoading, setPreviewLoading] = useState(true)
 
   useEffect(() => {
     if (!state) return
@@ -38,6 +40,13 @@ export default function ClientPaymentVerifyPage() {
     let cancelled = false
 
     async function start() {
+      // Fetch rate/fee preview in parallel — failure is non-fatal
+      paymentService.previewPayment({
+        fromAccount:      state.fromAccount.accountNumber,
+        recipientAccount: state.recipientAccount,
+        amount:           state.amount,
+      }).then(setPreview).catch(() => {}).finally(() => setPreviewLoading(false))
+
       try {
         const approval = await paymentService.createPaymentApproval({
           fromAccount:      state.fromAccount.accountNumber,
@@ -199,6 +208,24 @@ export default function ClientPaymentVerifyPage() {
           <Row label="Recipient"        value={recipientName} />
           <Row label="Recipient account" value={recipientAccount} />
           <Row label="Amount"           value={fmt(amount, fromAccount.currency)} />
+
+          {/* Cross-bank / cross-currency fee and rate — loaded asynchronously */}
+          {previewLoading && (
+            <div className="flex items-center justify-between py-2.5 border-b border-slate-100 dark:border-slate-800">
+              <span className="text-xs tracking-widest uppercase text-slate-400 dark:text-slate-500">Rate / Fee</span>
+              <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse">Fetching…</span>
+            </div>
+          )}
+          {!previewLoading && preview && (preview.isCrossBank || preview.exchangeRate > 1) && (
+            <>
+              {preview.exchangeRate > 0 && preview.exchangeRate !== 1 && (
+                <Row label="Exchange rate" value={`1 ${preview.fromCurrency} = ${preview.exchangeRate.toFixed(4)}`} />
+              )}
+              <Row label="Fee" value={preview.fee > 0 ? fmt(preview.fee, preview.fromCurrency) : 'No fee'} />
+              <Row label="Recipient receives" value={fmt(preview.finalAmount, preview.fromCurrency)} />
+            </>
+          )}
+
           <Row label="Payment code"     value={paymentCode} />
           {referenceNumber && <Row label="Reference" value={referenceNumber} />}
           <Row label="Purpose"          value={purpose} />

--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -68,4 +68,13 @@ export const paymentService = {
     const { data } = await clientApiClient.get(`/api/approvals/${id}/poll`)
     return data // { status }
   },
+
+  async previewPayment({ fromAccount, recipientAccount, amount }) {
+    const { data } = await clientApiClient.post('/api/payments/preview', {
+      fromAccount:      fromAccount.replace(/-/g, ''),
+      recipientAccount: recipientAccount.replace(/-/g, ''),
+      amount,
+    })
+    return data // { isCrossBank, exchangeRate, fee, finalAmount, fromCurrency }
+  },
 }


### PR DESCRIPTION
On mount, ClientPaymentVerifyPage calls POST /api/payments/preview in parallel with createPaymentApproval. The preview endpoint probes the partner bank with a 2PC NEW_TX then immediately sends ROLLBACK_TX to get the quoted exchange rate, fee, and final credited amount without committing any funds. The result is shown in the payment summary card before the user confirms: exchange rate row (if currencies differ), fee row, and recipient receives row. While the preview is in flight a pulsing "Fetching..." placeholder is shown. If the preview call fails or the partner bank is unreachable the rows are silently omitted and the approval flow continues unaffected.