### PR TITLE
feat(#219,#220): cross-bank OTC market and negotiation UI + bug fixes

### DIFF
--- a/src/pages/client/ClientOtcContractsPage.jsx
+++ b/src/pages/client/ClientOtcContractsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import useWindowTitle from '../../hooks/useWindowTitle'
+import { useClientAuth } from '../../context/ClientAuthContext'
 import { clientOtcService } from '../../services/clientOtcService'
 import { fmt, fmtDate } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
@@ -85,6 +86,7 @@ function ExerciseModal({ contract, onClose, onConfirm }) {
 
 export default function ClientOtcContractsPage() {
   useWindowTitle('OTC Contracts | AnkaBanka')
+  const { clientUser } = useClientAuth()
 
   const [contracts,    setContracts]    = useState([])
   const [loading,      setLoading]      = useState(true)
@@ -208,7 +210,7 @@ export default function ClientOtcContractsPage() {
                           {c.profit != null ? `${c.profit >= 0 ? '+' : ''}${fmt(c.profit)}` : '—'}
                         </td>
                         <td className="px-4 py-3">
-                          {c.status === 'ACTIVE' && (
+                          {c.status === 'ACTIVE' && c.buyerType === 'CLIENT' && c.buyerId === clientUser?.id && (
                             <button
                               onClick={() => setExerciseItem(c)}
                               className="btn-primary text-xs px-3 py-1"

--- a/src/pages/client/ClientOtcMarketPage.jsx
+++ b/src/pages/client/ClientOtcMarketPage.jsx
@@ -5,11 +5,14 @@ import { clientOtcService } from '../../services/clientOtcService'
 import { fmt, fmtDateTime } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 
+const CURRENCIES = ['USD', 'EUR', 'RSD', 'CHF', 'GBP', 'JPY', 'AUD', 'CAD']
+
 function OfferModal({ item, onClose, onSubmit }) {
   const [quantity,       setQuantity]       = useState('')
   const [pricePerShare,  setPricePerShare]  = useState('')
   const [premium,        setPremium]        = useState('')
   const [settlementDate, setSettlementDate] = useState('')
+  const [currency,       setCurrency]       = useState(item.currency ?? 'USD')
   const [submitting,     setSubmitting]     = useState(false)
   const [error,          setError]          = useState(null)
 
@@ -22,16 +25,22 @@ function OfferModal({ item, onClose, onSubmit }) {
     setSubmitting(true)
     setError(null)
     try {
-      await onSubmit({
+      const payload = {
         ticker:         item.ticker,
         amount:         Number(quantity),
         pricePerStock:  Number(pricePerShare),
         premium:        premium ? Number(premium) : 0,
         settlementDate,
-        sellerId:       item.ownerId,
-        sellerType:     item.ownerType,
-        currency:       item.currency,
-      })
+        currency,
+      }
+      if (item.isExternal) {
+        payload.sellerRoutingNumber = item.sellerRoutingNumber
+        payload.sellerExternalId   = item.sellerExternalId
+      } else {
+        payload.sellerId   = item.ownerId
+        payload.sellerType = item.ownerType
+      }
+      await onSubmit(payload)
       onClose()
     } catch (err) {
       setError(err?.response?.data?.error || 'Failed to submit offer. Please try again.')
@@ -101,6 +110,21 @@ function OfferModal({ item, onClose, onSubmit }) {
             />
           </div>
 
+          {item.isExternal && (
+            <div>
+              <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
+                Currency
+              </label>
+              <select
+                value={currency}
+                onChange={e => setCurrency(e.target.value)}
+                className="input-field w-full"
+              >
+                {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+          )}
+
           <div>
             <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
               Settlement Date
@@ -150,9 +174,30 @@ export default function ClientOtcMarketPage() {
   useEffect(() => {
     setLoading(true)
     setError(null)
-    clientOtcService.getMarket()
-      .then(data => setItems(Array.isArray(data) ? data : (data.items ?? [])))
-      .catch(() => setError(true))
+
+    Promise.all([
+      clientOtcService.getMarket().catch(() => []),
+      clientOtcService.getExternalStocks().catch(() => ({ items: [], bankName: '' })),
+    ]).then(([local, external]) => {
+      const localItems = Array.isArray(local) ? local : (local.items ?? [])
+
+      const bankName = external.bankName ?? ''
+      const externalItems = (external.items ?? []).flatMap(entry =>
+        (entry.sellers ?? []).map(s => ({
+          ticker:              entry.stock?.ticker ?? '',
+          name:                entry.stock?.name ?? '',
+          pricePerStock:       entry.stock?.price,
+          currency:            entry.stock?.currency ?? '',
+          amount:              s.amount,
+          ownerBank:           bankName,
+          sellerRoutingNumber: s.seller?.routingNumber,
+          sellerExternalId:    String(s.seller?.id ?? ''),
+          isExternal:          true,
+        }))
+      )
+
+      setItems([...localItems, ...externalItems])
+    }).catch(() => setError(true))
       .finally(() => setLoading(false))
   }, [])
 
@@ -226,9 +271,17 @@ export default function ClientOtcMarketPage() {
                           {fmtDateTime(item.lastUpdated)}
                         </td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 text-xs">
-                          <div>{item.ownerName ?? '—'}</div>
-                          {item.ownerBank && (
-                            <div className="text-slate-400 dark:text-slate-500">{item.ownerBank}</div>
+                          {item.isExternal ? (
+                            <span className="inline-block bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs px-2 py-0.5 rounded">
+                              {item.ownerBank || 'Partner Bank'}
+                            </span>
+                          ) : (
+                            <>
+                              <div>{item.ownerName ?? '—'}</div>
+                              {item.ownerBank && (
+                                <div className="text-slate-400 dark:text-slate-500">{item.ownerBank}</div>
+                              )}
+                            </>
                           )}
                         </td>
                         <td className="px-4 py-3">

--- a/src/pages/client/ClientOtcNegotiationDetailPage.jsx
+++ b/src/pages/client/ClientOtcNegotiationDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClientAuth } from '../../context/ClientAuthContext'
@@ -44,12 +44,15 @@ export default function ClientOtcNegotiationDetailPage() {
   const [showCounter,    setShowCounter]    = useState(false)
   const [showAcceptConfirm, setShowAcceptConfirm] = useState(false)
 
+  const negRef = useRef(null)
+
   useEffect(() => {
     setLoading(true)
     setError(null)
     clientOtcService.getNegotiation(id)
       .then(data => {
         setNeg(data)
+        negRef.current = data
         if (data?.ticker) {
           clientSecuritiesService.getListings({ ticker: data.ticker })
             .then(r => {
@@ -62,6 +65,18 @@ export default function ClientOtcNegotiationDetailPage() {
       })
       .catch(() => setError(true))
       .finally(() => setLoading(false))
+  }, [id])
+
+  // Poll every 10 s for cross-bank negotiations so counter-offers from the partner appear automatically.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const current = negRef.current
+      if (!current || (current.sellerType !== 'INTERBANK' && current.buyerType !== 'INTERBANK')) return
+      clientOtcService.getNegotiation(id)
+        .then(data => { setNeg(data); negRef.current = data })
+        .catch(() => {})
+    }, 10000)
+    return () => clearInterval(interval)
   }, [id])
 
   const userId = clientUser?.id
@@ -208,7 +223,7 @@ export default function ClientOtcNegotiationDetailPage() {
                 </Field>
               </div>
 
-              <div className="mt-5 pt-5 border-t border-slate-100 dark:border-slate-800">
+              <div className="mt-5 pt-5 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between">
                 <span className={`text-xs font-medium ${
                   isMyTurn
                     ? 'text-violet-600 dark:text-violet-400'
@@ -216,6 +231,11 @@ export default function ClientOtcNegotiationDetailPage() {
                 }`}>
                   {isMyTurn ? 'Your turn' : 'Waiting for the other party'}
                 </span>
+                {(neg.sellerType === 'INTERBANK' || neg.buyerType === 'INTERBANK') && (
+                  <span className="inline-block bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs px-2 py-0.5 rounded">
+                    {neg.sellerName || 'Partner Bank'}
+                  </span>
+                )}
               </div>
             </div>
 

--- a/src/pages/client/ClientOtcNegotiationsPage.jsx
+++ b/src/pages/client/ClientOtcNegotiationsPage.jsx
@@ -124,6 +124,7 @@ export default function ClientOtcNegotiationsPage() {
                 <thead>
                   <tr className="border-b border-slate-200 dark:border-slate-700">
                     <th className={thClass(false)}>Ticker</th>
+                    <th className={thClass(false)}>Bank</th>
                     <th className={thClass(false)}>Amount</th>
                     <th className={thClass(true)} onClick={() => handleSort('pricePerStock')}>
                       Price / Share<SortIcon col="pricePerStock" />
@@ -142,7 +143,7 @@ export default function ClientOtcNegotiationsPage() {
                 <tbody>
                   {sorted.length === 0 ? (
                     <tr>
-                      <td colSpan={8} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                      <td colSpan={9} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
                         You have no active negotiations.
                       </td>
                     </tr>
@@ -161,6 +162,15 @@ export default function ClientOtcNegotiationsPage() {
                         >
                           <td className="px-4 py-3 font-mono font-medium text-slate-800 dark:text-slate-200">
                             {neg.ticker}
+                          </td>
+                          <td className="px-4 py-3">
+                            {neg.sellerType === 'INTERBANK' || neg.buyerType === 'INTERBANK' ? (
+                              <span className="inline-block bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs px-2 py-0.5 rounded">
+                                {neg.sellerName || 'Partner Bank'}
+                              </span>
+                            ) : (
+                              <span className="text-xs text-slate-400 dark:text-slate-500">Local</span>
+                            )}
                           </td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">
                             {neg.amount}

--- a/src/pages/otc/OtcMarketPage.jsx
+++ b/src/pages/otc/OtcMarketPage.jsx
@@ -4,11 +4,14 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { otcService } from '../../services/otcService'
 import { fmt, fmtDateTime } from '../../utils/formatting'
 
+const CURRENCIES = ['USD', 'EUR', 'RSD', 'CHF', 'GBP', 'JPY', 'AUD', 'CAD']
+
 function OfferModal({ item, onClose, onSubmit }) {
   const [quantity,       setQuantity]       = useState('')
   const [pricePerShare,  setPricePerShare]  = useState('')
   const [premium,        setPremium]        = useState('')
   const [settlementDate, setSettlementDate] = useState('')
+  const [currency,       setCurrency]       = useState(item.currency ?? 'USD')
   const [submitting,     setSubmitting]     = useState(false)
   const [error,          setError]          = useState(null)
 
@@ -21,16 +24,22 @@ function OfferModal({ item, onClose, onSubmit }) {
     setSubmitting(true)
     setError(null)
     try {
-      await onSubmit({
+      const payload = {
         ticker:         item.ticker,
         amount:         Number(quantity),
         pricePerStock:  Number(pricePerShare),
         premium:        premium ? Number(premium) : 0,
         settlementDate,
-        sellerId:       item.ownerId,
-        sellerType:     item.ownerType,
-        currency:       item.currency,
-      })
+        currency,
+      }
+      if (item.isExternal) {
+        payload.sellerRoutingNumber = item.sellerRoutingNumber
+        payload.sellerExternalId   = item.sellerExternalId
+      } else {
+        payload.sellerId   = item.ownerId
+        payload.sellerType = item.ownerType
+      }
+      await onSubmit(payload)
       onClose()
     } catch (err) {
       setError(err?.response?.data?.error || 'Failed to submit offer. Please try again.')
@@ -100,6 +109,21 @@ function OfferModal({ item, onClose, onSubmit }) {
             />
           </div>
 
+          {item.isExternal && (
+            <div>
+              <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
+                Currency
+              </label>
+              <select
+                value={currency}
+                onChange={e => setCurrency(e.target.value)}
+                className="input-field w-full"
+              >
+                {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+          )}
+
           <div>
             <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
               Settlement Date
@@ -149,9 +173,30 @@ export default function OtcMarketPage() {
   useEffect(() => {
     setLoading(true)
     setError(null)
-    otcService.getMarket()
-      .then(data => setItems(Array.isArray(data) ? data : (data.items ?? [])))
-      .catch(() => setError(true))
+
+    Promise.all([
+      otcService.getMarket().catch(() => []),
+      otcService.getExternalStocks().catch(() => ({ items: [], bankName: '' })),
+    ]).then(([local, external]) => {
+      const localItems = Array.isArray(local) ? local : (local.items ?? [])
+
+      const bankName = external.bankName ?? ''
+      const externalItems = (external.items ?? []).flatMap(entry =>
+        (entry.sellers ?? []).map(s => ({
+          ticker:              entry.stock?.ticker ?? '',
+          name:                entry.stock?.name ?? '',
+          pricePerStock:       entry.stock?.price,
+          currency:            entry.stock?.currency ?? '',
+          amount:              s.amount,
+          ownerBank:           bankName,
+          sellerRoutingNumber: s.seller?.routingNumber,
+          sellerExternalId:    String(s.seller?.id ?? ''),
+          isExternal:          true,
+        }))
+      )
+
+      setItems([...localItems, ...externalItems])
+    }).catch(() => setError(true))
       .finally(() => setLoading(false))
   }, [])
 
@@ -226,9 +271,17 @@ export default function OtcMarketPage() {
                           {fmtDateTime(item.lastUpdated)}
                         </td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 text-xs">
-                          <div>{item.ownerName ?? '—'}</div>
-                          {item.ownerBank && (
-                            <div className="text-slate-400 dark:text-slate-500">{item.ownerBank}</div>
+                          {item.isExternal ? (
+                            <span className="inline-block bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs px-2 py-0.5 rounded">
+                              {item.ownerBank || 'Partner Bank'}
+                            </span>
+                          ) : (
+                            <>
+                              <div>{item.ownerName ?? '—'}</div>
+                              {item.ownerBank && (
+                                <div className="text-slate-400 dark:text-slate-500">{item.ownerBank}</div>
+                              )}
+                            </>
                           )}
                         </td>
                         <td className="px-4 py-3">

--- a/src/pages/otc/OtcNegotiationDetailPage.jsx
+++ b/src/pages/otc/OtcNegotiationDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
@@ -43,12 +43,15 @@ export default function OtcNegotiationDetailPage() {
   const [showCounter,   setShowCounter]   = useState(false)
   const [showAcceptConfirm, setShowAcceptConfirm] = useState(false)
 
+  const negRef = useRef(null)
+
   useEffect(() => {
     setLoading(true)
     setError(null)
     otcService.getNegotiation(id)
       .then(data => {
         setNeg(data)
+        negRef.current = data
         if (data?.ticker) {
           securitiesService.getListings({ ticker: data.ticker })
             .then(r => {
@@ -63,9 +66,21 @@ export default function OtcNegotiationDetailPage() {
       .finally(() => setLoading(false))
   }, [id])
 
+  // Poll every 10 s for cross-bank negotiations so counter-offers from the partner appear automatically.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const current = negRef.current
+      if (!current || (current.sellerType !== 'INTERBANK' && current.buyerType !== 'INTERBANK')) return
+      otcService.getNegotiation(id)
+        .then(data => { setNeg(data); negRef.current = data })
+        .catch(() => {})
+    }, 10000)
+    return () => clearInterval(interval)
+  }, [id])
+
   const userId = user?.id
   const isMyTurn = neg &&
-    ((neg.status === 'PENDING_SELLER' && neg.sellerType === 'EMPLOYEE' && neg.sellerId === userId) ||
+    ((neg.status === 'PENDING_SELLER' && neg.sellerType === 'EMPLOYEE' && (neg.sellerId === userId || neg.sellerId === 0)) ||
      (neg.status === 'PENDING_BUYER'  && neg.buyerType  === 'EMPLOYEE' && neg.buyerId  === userId))
 
   function apiError(err, fallback) {
@@ -183,7 +198,7 @@ export default function OtcNegotiationDetailPage() {
                 </Field>
               </div>
 
-              <div className="mt-5 pt-5 border-t border-slate-100 dark:border-slate-800">
+              <div className="mt-5 pt-5 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between">
                 <span className={`text-xs font-medium ${
                   isMyTurn
                     ? 'text-violet-600 dark:text-violet-400'
@@ -191,6 +206,11 @@ export default function OtcNegotiationDetailPage() {
                 }`}>
                   {isMyTurn ? 'Your turn' : 'Waiting for the other party'}
                 </span>
+                {(neg.sellerType === 'INTERBANK' || neg.buyerType === 'INTERBANK') && (
+                  <span className="inline-block bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs px-2 py-0.5 rounded">
+                    {neg.sellerName || 'Partner Bank'}
+                  </span>
+                )}
               </div>
             </div>
 

--- a/src/pages/otc/OtcNegotiationsPage.jsx
+++ b/src/pages/otc/OtcNegotiationsPage.jsx
@@ -18,7 +18,7 @@ function getPriceColor(price, market) {
 
 function getStatusLabel(neg, userId) {
   const myTurn =
-    (neg.status === 'PENDING_SELLER' && neg.sellerType === 'EMPLOYEE' && neg.sellerId === userId) ||
+    (neg.status === 'PENDING_SELLER' && neg.sellerType === 'EMPLOYEE' && (neg.sellerId === userId || neg.sellerId === 0)) ||
     (neg.status === 'PENDING_BUYER'  && neg.buyerType  === 'EMPLOYEE' && neg.buyerId  === userId)
   return myTurn ? 'Your turn' : 'Waiting for the other party'
 }
@@ -124,6 +124,7 @@ export default function OtcNegotiationsPage() {
                 <thead>
                   <tr className="border-b border-slate-200 dark:border-slate-700">
                     <th className={thClass(false)}>Ticker</th>
+                    <th className={thClass(false)}>Bank</th>
                     <th className={thClass(false)}>Amount</th>
                     <th className={thClass(true)} onClick={() => handleSort('pricePerStock')}>
                       Price / Share<SortIcon col="pricePerStock" />
@@ -142,7 +143,7 @@ export default function OtcNegotiationsPage() {
                 <tbody>
                   {sorted.length === 0 ? (
                     <tr>
-                      <td colSpan={8} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
+                      <td colSpan={9} className="px-4 py-12 text-center text-slate-400 dark:text-slate-500 text-sm">
                         You have no active negotiations.
                       </td>
                     </tr>
@@ -161,6 +162,15 @@ export default function OtcNegotiationsPage() {
                         >
                           <td className="px-4 py-3 font-mono font-medium text-slate-800 dark:text-slate-200">
                             {neg.ticker}
+                          </td>
+                          <td className="px-4 py-3">
+                            {neg.sellerType === 'INTERBANK' || neg.buyerType === 'INTERBANK' ? (
+                              <span className="inline-block bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 text-xs px-2 py-0.5 rounded">
+                                {neg.sellerName || 'Partner Bank'}
+                              </span>
+                            ) : (
+                              <span className="text-xs text-slate-400 dark:text-slate-500">Local</span>
+                            )}
                           </td>
                           <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">
                             {neg.amount}

--- a/src/services/clientOtcService.js
+++ b/src/services/clientOtcService.js
@@ -36,6 +36,11 @@ export const clientOtcService = {
     return data
   },
 
+  async getExternalStocks() {
+    const { data } = await clientApiClient.get('/api/otc/external-stocks')
+    return data
+  },
+
   async getContracts(status) {
     const { data } = await clientApiClient.get('/otc/contracts', { params: status ? { status } : undefined })
     return data

--- a/src/services/otcService.js
+++ b/src/services/otcService.js
@@ -36,6 +36,11 @@ export const otcService = {
     return data
   },
 
+  async getExternalStocks() {
+    const { data } = await apiClient.get('/api/otc/external-stocks')
+    return data
+  },
+
   async getContracts(status) {
     const { data } = await apiClient.get('/otc/contracts', { params: status ? { status } : undefined })
     return data


### PR DESCRIPTION
- OtcMarketPage/ClientOtcMarketPage: fetch and merge partner bank stocks, show name/price/currency for external items, currency selector in offer modal
- OtcNegotiationsPage/ClientOtcNegotiationsPage: Bank column with partner badge, isMyTurn treats seller_id=0 (bank) as any employee's turn
- OtcNegotiationDetailPage/ClientOtcNegotiationDetailPage: 10s polling for cross-bank negotiations, partner bank badge, bank-seller turn support
- ClientOtcContractsPage: restrict Exercise button to buyer only
- clientOtcService/otcService: add getExternalStocks()