### PR TITLE
feat: make API URL configurable at runtime without rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-ARG VITE_API_URL=http://localhost:8083
-ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 80
+CMD ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cat > /usr/share/nginx/html/config.js << EOF
+window.__ENV__ = {
+  API_URL: "${API_URL:-http://localhost:8083}"
+}
+EOF
+exec nginx -g 'daemon off;'

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap"
       rel="stylesheet"
     />
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,3 @@
+window.__ENV__ = {
+  API_URL: "http://localhost:8083"
+}

--- a/src/pages/client/ClientActivatePage.jsx
+++ b/src/pages/client/ClientActivatePage.jsx
@@ -3,7 +3,7 @@ import { useSearchParams, Link } from 'react-router-dom'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import axios from 'axios'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
+const BASE_URL = window.__ENV__?.API_URL ?? 'http://localhost:8083'
 
 const MIN_LENGTH = 8
 const MAX_LENGTH = 32

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -15,7 +15,7 @@
 import axios from 'axios'
 import { tokenService } from './tokenService'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
+const BASE_URL = window.__ENV__?.API_URL ?? 'http://localhost:8083'
 
 // ── Bare client used only for token refresh ─────────────────────────────────
 // No interceptors — prevents infinite 401 loop if the refresh endpoint itself

--- a/src/services/clientApiClient.js
+++ b/src/services/clientApiClient.js
@@ -9,7 +9,7 @@
 import axios from 'axios'
 import { clientTokenService } from './clientTokenService'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
+const BASE_URL = window.__ENV__?.API_URL ?? 'http://localhost:8083'
 
 // Bare client used only for the refresh call — no interceptors to avoid loops.
 export const clientRefreshAxios = axios.create({ baseURL: BASE_URL })

--- a/src/services/clientAuthService.js
+++ b/src/services/clientAuthService.js
@@ -8,7 +8,7 @@
 import axios from 'axios'
 import { clientTokenService } from './clientTokenService'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8083'
+const BASE_URL = window.__ENV__?.API_URL ?? 'http://localhost:8083'
 
 function decodeJwtPayload(token) {
   const payload = token.split('.')[1]


### PR DESCRIPTION
## Summary

- Adds `public/config.js` — served by Vite in dev, overwritten by entrypoint at runtime in Docker/K8s
- Adds `entrypoint.sh` — writes `config.js` from `\$API_URL` env var before nginx starts
- Updates `index.html` to load `/config.js` before the app bundle
- Replaces `import.meta.env.VITE_API_URL` with `window.__ENV__?.API_URL` in all 4 files that used it
- Cleans up now-unused `ARG VITE_API_URL` from Dockerfile

The backend URL can now be changed by setting the `API_URL` env var and restarting the container — no image rebuild needed.

## Test plan

- [ ] `npm run dev` — app still works at http://localhost:5173
- [ ] `docker compose up --build frontend` — app works at http://localhost:3000
- [ ] `docker run -p 3000:80 -e API_URL=https://test.example.com <image>` → `curl localhost:3000/config.js` shows the new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)