### PR TITLE
fix(cypress): increase exchange rates assertion timeout in Celina 2

### DIFF
--- a/cypress/e2e/celina2/exchange.cy.js
+++ b/cypress/e2e/celina2/exchange.cy.js
@@ -119,8 +119,8 @@ describe('Menjačnica — scenarios 24–26', () => {
         cy.contains('h1', 'Exchange').should('be.visible')
 
         // Wait for rates to load — estimatedReceive depends on rates being in state
-        cy.contains('th', 'Selling').should('be.visible')
-        cy.get('tbody td.font-mono').first().should('be.visible')
+        cy.contains('th', 'Selling', { timeout: 15000 }).should('be.visible')
+        cy.get('tbody td.font-mono', { timeout: 15000 }).first().should('be.visible')
 
         // Step 1: select accounts (form is below the rates table — scroll first)
         cy.contains('Select accounts').scrollIntoView()


### PR DESCRIPTION
## Summary

- Increases Cypress assertion timeout from 4s to 15s for the `cy.contains('th', 'Selling')` check in Scenario 25
- The exchange rates API on first daily load calls an external API (`open.er-api.com`) with an 8-second timeout, which can exceed Cypress's default 4s assertion timeout
- Scenario 24 masks this because it first waits for 'Buying' (burning time), then 'Selling' is already present — Scenario 25 jumps directly to 'Selling' so hits the 4s limit

## Test plan

- [ ] Celina 2 CI check passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)