### PR TITLE
feat(otc): add account selector for premium and exercise payment

### DIFF
--- a/src/pages/client/ClientOtcContractsPage.jsx
+++ b/src/pages/client/ClientOtcContractsPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClientAuth } from '../../context/ClientAuthContext'
 import { clientOtcService } from '../../services/clientOtcService'
+import { clientApiClient } from '../../services/clientApiClient'
 import { fmt, fmtDate } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 
@@ -11,15 +12,30 @@ const TABS = [
 ]
 
 function ExerciseModal({ contract, onClose, onConfirm }) {
-  const [submitting, setSubmitting] = useState(false)
-  const [error,      setError]      = useState(null)
+  const [submitting,        setSubmitting]        = useState(false)
+  const [error,             setError]             = useState(null)
+  const [accounts,          setAccounts]          = useState([])
+  const [selectedAccountId, setSelectedAccountId] = useState('')
+  const [accountsLoading,   setAccountsLoading]   = useState(true)
   const total = (contract.strikePrice ?? 0) * (contract.amount ?? 0)
+
+  useEffect(() => {
+    clientApiClient.get('/api/accounts/my')
+      .then(r => {
+        const list = Array.isArray(r.data) ? r.data : (r.data.accounts ?? r.data.items ?? [])
+        setAccounts(list)
+        const first = list[0]
+        if (first) setSelectedAccountId(String(first.accountId ?? first.id ?? ''))
+      })
+      .catch(() => setAccounts([]))
+      .finally(() => setAccountsLoading(false))
+  }, [])
 
   async function handleConfirm() {
     setSubmitting(true)
     setError(null)
     try {
-      await onConfirm(contract.id)
+      await onConfirm(contract.id, selectedAccountId ? Number(selectedAccountId) : undefined)
       onClose()
     } catch {
       setError('Failed to exercise contract. Please try again.')
@@ -62,6 +78,34 @@ function ExerciseModal({ contract, onClose, onConfirm }) {
           </div>
         </div>
 
+        {accountsLoading ? (
+          <p className="text-xs text-slate-400 dark:text-slate-500 mb-4">Loading accounts…</p>
+        ) : accounts.length === 0 ? (
+          <p className="text-xs text-red-500 mb-4">No active accounts found.</p>
+        ) : (
+          <div className="mb-4">
+            <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
+              Deduct from
+            </label>
+            <select
+              value={selectedAccountId}
+              onChange={e => setSelectedAccountId(e.target.value)}
+              className="w-full border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-white text-sm rounded px-3 py-2"
+            >
+              {accounts.map(a => {
+                const id = a.accountId ?? a.id
+                const currency = a.currency ?? a.currencyCode ?? ''
+                const balance = a.availableBalance ?? 0
+                return (
+                  <option key={id} value={id}>
+                    {a.accountName ?? a.accountNumber} — {currency} {fmt(balance)} available
+                  </option>
+                )
+              })}
+            </select>
+          </div>
+        )}
+
         {error && <p className="text-red-500 text-xs mb-3">{error}</p>}
 
         <div className="flex gap-3">
@@ -73,7 +117,7 @@ function ExerciseModal({ contract, onClose, onConfirm }) {
           </button>
           <button
             onClick={handleConfirm}
-            disabled={submitting}
+            disabled={submitting || accountsLoading || accounts.length === 0}
             className="flex-1 btn-primary text-sm py-2 disabled:opacity-50"
           >
             {submitting ? 'Processing…' : 'Confirm Exercise'}
@@ -117,8 +161,8 @@ export default function ClientOtcContractsPage() {
 
   useEffect(() => { loadContracts(activeTab) }, [activeTab])
 
-  async function handleExercise(id) {
-    await clientOtcService.exerciseContract(id, undefined)
+  async function handleExercise(id, buyerAccountId) {
+    await clientOtcService.exerciseContract(id, buyerAccountId)
     await loadContracts(activeTab)
   }
 

--- a/src/pages/client/ClientOtcNegotiationDetailPage.jsx
+++ b/src/pages/client/ClientOtcNegotiationDetailPage.jsx
@@ -4,6 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useClientAuth } from '../../context/ClientAuthContext'
 import { clientOtcService } from '../../services/clientOtcService'
 import { clientSecuritiesService } from '../../services/clientSecuritiesService'
+import { clientApiClient } from '../../services/clientApiClient'
 import { fmt, fmtDate, fmtDateTime } from '../../utils/formatting'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 
@@ -43,6 +44,10 @@ export default function ClientOtcNegotiationDetailPage() {
   const [counterPremium, setCounterPremium] = useState('')
   const [showCounter,    setShowCounter]    = useState(false)
   const [showAcceptConfirm, setShowAcceptConfirm] = useState(false)
+
+  const [accounts,          setAccounts]          = useState([])
+  const [selectedAccountId, setSelectedAccountId] = useState('')
+  const [accountsLoading,   setAccountsLoading]   = useState(false)
 
   const negRef = useRef(null)
 
@@ -86,6 +91,20 @@ export default function ClientOtcNegotiationDetailPage() {
 
   const [accepted, setAccepted] = useState(false)
 
+  useEffect(() => {
+    if (!showAcceptConfirm) return
+    setAccountsLoading(true)
+    clientApiClient.get('/api/accounts/my')
+      .then(r => {
+        const list = Array.isArray(r.data) ? r.data : (r.data.accounts ?? r.data.items ?? [])
+        setAccounts(list)
+        const first = list[0]
+        if (first) setSelectedAccountId(String(first.accountId ?? first.id ?? ''))
+      })
+      .catch(() => setAccounts([]))
+      .finally(() => setAccountsLoading(false))
+  }, [showAcceptConfirm])
+
   function apiError(err, fallback) {
     return err?.response?.data?.error || fallback
   }
@@ -94,7 +113,7 @@ export default function ClientOtcNegotiationDetailPage() {
     setActing(true)
     setActionError(null)
     try {
-      await clientOtcService.acceptNegotiation(id)
+      await clientOtcService.acceptNegotiation(id, selectedAccountId ? Number(selectedAccountId) : undefined)
       setAccepted(true)
     } catch (err) {
       setActionError(apiError(err, 'Failed to accept negotiation.'))
@@ -274,13 +293,42 @@ export default function ClientOtcNegotiationDetailPage() {
                 {showAcceptConfirm && (
                   <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
                     <p className="text-sm text-slate-700 dark:text-slate-300 mb-1">
-                      Accept this offer? Premium payable: <strong>{fmt(neg.premium)}</strong>
+                      Accept this offer? Premium payable: <strong>{fmt(neg.premium)} {neg.currency}</strong>
                     </p>
                     <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">This action cannot be undone.</p>
+
+                    {accountsLoading ? (
+                      <p className="text-xs text-slate-400 dark:text-slate-500 mb-4">Loading accounts…</p>
+                    ) : accounts.length === 0 ? (
+                      <p className="text-xs text-red-500 mb-4">No active accounts found.</p>
+                    ) : (
+                      <div className="mb-4">
+                        <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
+                          Deduct premium from
+                        </label>
+                        <select
+                          value={selectedAccountId}
+                          onChange={e => setSelectedAccountId(e.target.value)}
+                          className="input-field w-full"
+                        >
+                          {accounts.map(a => {
+                            const id = a.accountId ?? a.id
+                            const currency = a.currency ?? a.currencyCode ?? ''
+                            const balance = a.availableBalance ?? 0
+                            return (
+                              <option key={id} value={id}>
+                                {a.accountName ?? a.accountNumber} — {currency} {fmt(balance)} available
+                              </option>
+                            )
+                          })}
+                        </select>
+                      </div>
+                    )}
+
                     <div className="flex gap-3">
                       <button
                         onClick={handleAccept}
-                        disabled={acting}
+                        disabled={acting || accounts.length === 0}
                         className="btn-primary px-5 py-2 text-sm disabled:opacity-50"
                       >
                         {acting ? 'Processing…' : 'Confirm Accept'}

--- a/src/pages/otc/OtcContractsPage.jsx
+++ b/src/pages/otc/OtcContractsPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
 import { otcService } from '../../services/otcService'
+import { apiClient } from '../../services/apiClient'
 import { fmt, fmtDate } from '../../utils/formatting'
 
 const TABS = [
@@ -10,15 +11,30 @@ const TABS = [
 ]
 
 function ExerciseModal({ contract, onClose, onConfirm }) {
-  const [submitting, setSubmitting] = useState(false)
-  const [error,      setError]      = useState(null)
+  const [submitting,        setSubmitting]        = useState(false)
+  const [error,             setError]             = useState(null)
+  const [accounts,          setAccounts]          = useState([])
+  const [selectedAccountId, setSelectedAccountId] = useState('')
+  const [accountsLoading,   setAccountsLoading]   = useState(true)
   const total = (contract.strikePrice ?? 0) * (contract.amount ?? 0)
+
+  useEffect(() => {
+    apiClient.get('/api/accounts/my')
+      .then(r => {
+        const list = Array.isArray(r.data) ? r.data : (r.data.accounts ?? r.data.items ?? [])
+        setAccounts(list)
+        const first = list[0]
+        if (first) setSelectedAccountId(String(first.accountId ?? first.id ?? ''))
+      })
+      .catch(() => setAccounts([]))
+      .finally(() => setAccountsLoading(false))
+  }, [])
 
   async function handleConfirm() {
     setSubmitting(true)
     setError(null)
     try {
-      await onConfirm(contract.id)
+      await onConfirm(contract.id, selectedAccountId ? Number(selectedAccountId) : undefined)
       onClose()
     } catch {
       setError('Failed to exercise contract. Please try again.')
@@ -61,6 +77,34 @@ function ExerciseModal({ contract, onClose, onConfirm }) {
           </div>
         </div>
 
+        {accountsLoading ? (
+          <p className="text-xs text-slate-400 dark:text-slate-500 mb-4">Loading accounts…</p>
+        ) : accounts.length === 0 ? (
+          <p className="text-xs text-red-500 mb-4">No active accounts found.</p>
+        ) : (
+          <div className="mb-4">
+            <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
+              Deduct from
+            </label>
+            <select
+              value={selectedAccountId}
+              onChange={e => setSelectedAccountId(e.target.value)}
+              className="w-full border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-white text-sm rounded px-3 py-2"
+            >
+              {accounts.map(a => {
+                const id = a.accountId ?? a.id
+                const currency = a.currency ?? a.currencyCode ?? ''
+                const balance = a.availableBalance ?? 0
+                return (
+                  <option key={id} value={id}>
+                    {a.accountName ?? a.accountNumber} — {currency} {fmt(balance)} available
+                  </option>
+                )
+              })}
+            </select>
+          </div>
+        )}
+
         {error && <p className="text-red-500 text-xs mb-3">{error}</p>}
 
         <div className="flex gap-3">
@@ -72,7 +116,7 @@ function ExerciseModal({ contract, onClose, onConfirm }) {
           </button>
           <button
             onClick={handleConfirm}
-            disabled={submitting}
+            disabled={submitting || accountsLoading || accounts.length === 0}
             className="flex-1 btn-primary text-sm py-2 disabled:opacity-50"
           >
             {submitting ? 'Processing…' : 'Confirm Exercise'}
@@ -116,8 +160,8 @@ export default function OtcContractsPage() {
 
   useEffect(() => { loadContracts(activeTab) }, [activeTab])
 
-  async function handleExercise(id) {
-    await otcService.exerciseContract(id, undefined)
+  async function handleExercise(id, buyerAccountId) {
+    await otcService.exerciseContract(id, buyerAccountId)
     await loadContracts(activeTab)
   }
 

--- a/src/pages/otc/OtcNegotiationDetailPage.jsx
+++ b/src/pages/otc/OtcNegotiationDetailPage.jsx
@@ -4,6 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
 import { otcService } from '../../services/otcService'
 import { securitiesService } from '../../services/securitiesService'
+import { apiClient } from '../../services/apiClient'
 import { fmt, fmtDate, fmtDateTime } from '../../utils/formatting'
 
 function getPriceColor(price, market) {
@@ -42,6 +43,10 @@ export default function OtcNegotiationDetailPage() {
   const [counterPremium,setCounterPremium]= useState('')
   const [showCounter,   setShowCounter]   = useState(false)
   const [showAcceptConfirm, setShowAcceptConfirm] = useState(false)
+
+  const [accounts,          setAccounts]          = useState([])
+  const [selectedAccountId, setSelectedAccountId] = useState('')
+  const [accountsLoading,   setAccountsLoading]   = useState(false)
 
   const negRef = useRef(null)
 
@@ -83,6 +88,20 @@ export default function OtcNegotiationDetailPage() {
     ((neg.status === 'PENDING_SELLER' && neg.sellerType === 'EMPLOYEE' && (neg.sellerId === userId || neg.sellerId === 0)) ||
      (neg.status === 'PENDING_BUYER'  && neg.buyerType  === 'EMPLOYEE' && neg.buyerId  === userId))
 
+  useEffect(() => {
+    if (!showAcceptConfirm) return
+    setAccountsLoading(true)
+    apiClient.get('/api/accounts/my')
+      .then(r => {
+        const list = Array.isArray(r.data) ? r.data : (r.data.accounts ?? r.data.items ?? [])
+        setAccounts(list)
+        const first = list[0]
+        if (first) setSelectedAccountId(String(first.accountId ?? first.id ?? ''))
+      })
+      .catch(() => setAccounts([]))
+      .finally(() => setAccountsLoading(false))
+  }, [showAcceptConfirm])
+
   function apiError(err, fallback) {
     return err?.response?.data?.error || fallback
   }
@@ -91,7 +110,7 @@ export default function OtcNegotiationDetailPage() {
     setActing(true)
     setActionError(null)
     try {
-      await otcService.acceptNegotiation(id)
+      await otcService.acceptNegotiation(id, selectedAccountId ? Number(selectedAccountId) : undefined)
       navigate('/otc/negotiations')
     } catch (err) {
       setActionError(apiError(err, 'Failed to accept negotiation.'))
@@ -252,13 +271,42 @@ export default function OtcNegotiationDetailPage() {
                 {showAcceptConfirm && (
                   <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
                     <p className="text-sm text-slate-700 dark:text-slate-300 mb-1">
-                      Accept this offer? Premium payable: <strong>{fmt(neg.premium)}</strong>
+                      Accept this offer? Premium payable: <strong>{fmt(neg.premium)} {neg.currency}</strong>
                     </p>
                     <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">This action cannot be undone.</p>
+
+                    {accountsLoading ? (
+                      <p className="text-xs text-slate-400 dark:text-slate-500 mb-4">Loading accounts…</p>
+                    ) : accounts.length === 0 ? (
+                      <p className="text-xs text-red-500 mb-4">No active accounts found.</p>
+                    ) : (
+                      <div className="mb-4">
+                        <label className="block text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium mb-1">
+                          Deduct premium from
+                        </label>
+                        <select
+                          value={selectedAccountId}
+                          onChange={e => setSelectedAccountId(e.target.value)}
+                          className="input-field w-full"
+                        >
+                          {accounts.map(a => {
+                            const id = a.accountId ?? a.id
+                            const currency = a.currency ?? a.currencyCode ?? ''
+                            const balance = a.availableBalance ?? 0
+                            return (
+                              <option key={id} value={id}>
+                                {a.accountName ?? a.accountNumber} — {currency} {fmt(balance)} available
+                              </option>
+                            )
+                          })}
+                        </select>
+                      </div>
+                    )}
+
                     <div className="flex gap-3">
                       <button
                         onClick={handleAccept}
-                        disabled={acting}
+                        disabled={acting || accounts.length === 0}
                         className="btn-primary px-5 py-2 text-sm disabled:opacity-50"
                       >
                         {acting ? 'Processing…' : 'Confirm Accept'}

--- a/src/services/clientOtcService.js
+++ b/src/services/clientOtcService.js
@@ -21,8 +21,8 @@ export const clientOtcService = {
     return data
   },
 
-  async acceptNegotiation(id) {
-    const { data } = await clientApiClient.put(`/otc/negotiations/${id}/accept`)
+  async acceptNegotiation(id, buyerAccountId) {
+    const { data } = await clientApiClient.put(`/otc/negotiations/${id}/accept`, { buyerAccountId })
     return data
   },
 

--- a/src/services/otcService.js
+++ b/src/services/otcService.js
@@ -21,8 +21,8 @@ export const otcService = {
     return data
   },
 
-  async acceptNegotiation(id) {
-    const { data } = await apiClient.put(`/otc/negotiations/${id}/accept`)
+  async acceptNegotiation(id, buyerAccountId) {
+    const { data } = await apiClient.put(`/otc/negotiations/${id}/accept`, { buyerAccountId })
     return data
   },
 


### PR DESCRIPTION
Buyer can now choose which account to debit when accepting an OTC negotiation or exercising a contract. Accounts are fetched on demand and displayed with currency and available balance. Both employee and client portals updated (4 pages + 2 services).

Also fixes entrypoint.sh line endings (CRLF → LF) so it executes correctly inside the Alpine/nginx Docker container.