### PR TITLE
fix(frontend): convert entrypoint.sh to Unix line endings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 cat > /usr/share/nginx/html/config.js << EOF
 window.__ENV__ = {
   API_URL: "${API_URL:-http://localhost:8083}"


### PR DESCRIPTION
Windows CRLF endings caused the container to fail with exit 127 because Linux cannot find the #!/bin/sh\r interpreter.