### PR TITLE
fix(otc): send sellerId, sellerType, and currency for external offers

### DIFF
--- a/src/pages/client/ClientOtcMarketPage.jsx
+++ b/src/pages/client/ClientOtcMarketPage.jsx
@@ -36,6 +36,8 @@ function OfferModal({ item, onClose, onSubmit }) {
       if (item.isExternal) {
         payload.sellerRoutingNumber = item.sellerRoutingNumber
         payload.sellerExternalId   = item.sellerExternalId
+        payload.sellerId            = item.sellerId
+        payload.sellerType          = item.sellerType
       } else {
         payload.sellerId   = item.ownerId
         payload.sellerType = item.ownerType
@@ -187,11 +189,13 @@ export default function ClientOtcMarketPage() {
           ticker:              entry.stock?.ticker ?? '',
           name:                entry.stock?.name ?? '',
           pricePerStock:       entry.stock?.price,
-          currency:            entry.stock?.currency ?? '',
+          currency:            entry.stock?.currency || 'USD',
           amount:              s.amount,
           ownerBank:           bankName,
           sellerRoutingNumber: s.seller?.routingNumber,
           sellerExternalId:    String(s.seller?.id ?? ''),
+          sellerId:            Number(s.seller?.id ?? 0),
+          sellerType:          'CLIENT',
           isExternal:          true,
         }))
       )

--- a/src/pages/otc/OtcMarketPage.jsx
+++ b/src/pages/otc/OtcMarketPage.jsx
@@ -35,6 +35,8 @@ function OfferModal({ item, onClose, onSubmit }) {
       if (item.isExternal) {
         payload.sellerRoutingNumber = item.sellerRoutingNumber
         payload.sellerExternalId   = item.sellerExternalId
+        payload.sellerId            = item.sellerId
+        payload.sellerType          = item.sellerType
       } else {
         payload.sellerId   = item.ownerId
         payload.sellerType = item.ownerType
@@ -186,11 +188,13 @@ export default function OtcMarketPage() {
           ticker:              entry.stock?.ticker ?? '',
           name:                entry.stock?.name ?? '',
           pricePerStock:       entry.stock?.price,
-          currency:            entry.stock?.currency ?? '',
+          currency:            entry.stock?.currency || 'USD',
           amount:              s.amount,
           ownerBank:           bankName,
           sellerRoutingNumber: s.seller?.routingNumber,
           sellerExternalId:    String(s.seller?.id ?? ''),
+          sellerId:            Number(s.seller?.id ?? 0),
+          sellerType:          'CLIENT',
           isExternal:          true,
         }))
       )


### PR DESCRIPTION
The backend's CreateNegotiation endpoint requires sellerId, sellerType, and currency on all requests. For external (interbank) stocks:
- sellerId was never sent — mapped from s.seller.id (numeric)
- sellerType was never sent — set to 'CLIENT' per backend contract
- currency defaulted to '' when the partner bank omits the field — now falls back to 'USD' so the backend required-field check passes