### PR TITLE
feat(c4): OTC negotiation history UI + fund statistics views

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,6 +79,15 @@ import NotificationsPage from './pages/NotificationsPage'
 import ClientNotificationsPage from './pages/client/ClientNotificationsPage'
 import TotpSetupPage from './pages/auth/TotpSetupPage'
 import AccountSettingsPage from './pages/settings/AccountSettingsPage'
+import MyOrdersPage from './pages/orders/MyOrdersPage'
+import ClientMyOrdersPage from './pages/client/ClientMyOrdersPage'
+import WatchlistPage from './pages/watchlists/WatchlistPage'
+import ClientWatchlistPage from './pages/client/ClientWatchlistPage'
+import PriceAlertsPage from './pages/alerts/PriceAlertsPage'
+import ClientPriceAlertsPage from './pages/client/ClientPriceAlertsPage'
+import AuditLogPage from './pages/employee/AuditLogPage'
+import RecurringOrdersPage from './pages/orders/RecurringOrdersPage'
+import ClientRecurringOrdersPage from './pages/client/ClientRecurringOrdersPage'
 
 function App() {
   return (
@@ -132,6 +141,11 @@ function App() {
               <Route path="/notifications"           element={<NotificationsPage />} />
               <Route path="/settings/security"       element={<AccountSettingsPage />} />
               <Route path="/settings/totp"           element={<TotpSetupPage />} />
+              <Route path="/my-orders"               element={<MyOrdersPage />} />
+              <Route path="/watchlists"              element={<WatchlistPage />} />
+              <Route path="/price-alerts"            element={<PriceAlertsPage />} />
+              <Route path="/audit-log"               element={<AuditLogPage />} />
+              <Route path="/recurring-orders"        element={<RecurringOrdersPage />} />
             </Route>
           </Route>
 
@@ -171,6 +185,10 @@ function App() {
           <Route path="/client/investment/funds"     element={<ClientFundsDiscoveryPage />} />
           <Route path="/client/investment/funds/:id" element={<ClientFundDetailPage />} />
           <Route path="/client/notifications"        element={<ClientNotificationsPage />} />
+          <Route path="/client/my-orders"           element={<ClientMyOrdersPage />} />
+          <Route path="/client/watchlists"          element={<ClientWatchlistPage />} />
+          <Route path="/client/price-alerts"        element={<ClientPriceAlertsPage />} />
+          <Route path="/client/recurring-orders"    element={<ClientRecurringOrdersPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/layouts/ClientPortalLayout.jsx
+++ b/src/layouts/ClientPortalLayout.jsx
@@ -21,6 +21,10 @@ export const NAV_ITEMS = [
   { label: 'OTC Negotiations', href: '/client/otc/negotiations', icon: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z' },
   { label: 'OTC Contracts', href: '/client/otc/contracts', icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },
   { label: 'Notifications', href: '/client/notifications', icon: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9' },
+  { label: 'My Orders',     href: '/client/my-orders',    icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01' },
+  { label: 'Watchlists',    href: '/client/watchlists',   icon: 'M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z' },
+  { label: 'Price Alerts',  href: '/client/price-alerts', icon: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9' },
+  { label: 'Trajni Nalozi', href: '/client/recurring-orders', icon: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15' },
 ]
 
 export default function ClientPortalLayout({ children }) {

--- a/src/layouts/EmployeePortalLayout.jsx
+++ b/src/layouts/EmployeePortalLayout.jsx
@@ -116,6 +116,36 @@ export const NAV_ITEMS = [
     show: (p) => p?.isAdmin || p?.isAgent || p?.isSupervisor,
   },
   {
+    label: 'My Orders',
+    href: '/my-orders',
+    icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01',
+    show: (p) => p?.isAgent || p?.isSupervisor,
+  },
+  {
+    label: 'Watchlists',
+    href: '/watchlists',
+    icon: 'M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z',
+    show: (p) => p?.isAgent || p?.isSupervisor,
+  },
+  {
+    label: 'Price Alerts',
+    href: '/price-alerts',
+    icon: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9',
+    show: (p) => p?.isAgent || p?.isSupervisor,
+  },
+  {
+    label: 'Recurring Orders',
+    href: '/recurring-orders',
+    icon: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15',
+    show: (p) => p?.isAgent || p?.isSupervisor,
+  },
+  {
+    label: 'Audit Log',
+    href: '/audit-log',
+    icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+    show: (p) => p?.isSupervisor || p?.isAdmin,
+  },
+  {
     label: 'Security Settings',
     href: '/settings/security',
     icon: 'M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z',

--- a/src/pages/alerts/PriceAlertsPage.jsx
+++ b/src/pages/alerts/PriceAlertsPage.jsx
@@ -1,0 +1,283 @@
+import { useEffect, useRef, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { usePermission } from '../../hooks/usePermission'
+import { useApiError } from '../../context/ApiErrorContext'
+import { priceAlertService } from '../../services/priceAlertService'
+import { securitiesService } from '../../services/securitiesService'
+import { fmt } from '../../utils/formatting'
+
+const CONDITION_LABELS = {
+  ABOVE:           'Above',
+  BELOW:           'Below',
+  CHANGE_PCT_UP:   '% Up',
+  CHANGE_PCT_DOWN: '% Down',
+}
+
+const CONDITION_BADGE = {
+  ABOVE:           'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  BELOW:           'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+  CHANGE_PCT_UP:   'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  CHANGE_PCT_DOWN: 'bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+}
+
+export default function PriceAlertsPage() {
+  useWindowTitle('Price Alerts | AnkaBanka')
+  const { canAny } = usePermission()
+  if (!canAny(['isAgent', 'isSupervisor'])) return <Navigate to="/" replace />
+
+  const { addSuccess } = useApiError()
+  const [alerts, setAlerts]     = useState([])
+  const [loading, setLoading]   = useState(true)
+  const [deleting, setDeleting] = useState({})
+
+  // New alert modal
+  const [showNew, setShowNew]           = useState(false)
+  const [newSearch, setNewSearch]       = useState('')
+  const [newResults, setNewResults]     = useState([])
+  const [newSearchLoading, setNewSearchLoading] = useState(false)
+  const [newListing, setNewListing]     = useState(null)
+  const [newCondition, setNewCondition] = useState('ABOVE')
+  const [newThreshold, setNewThreshold] = useState('')
+  const [newNotifType, setNewNotifType] = useState('BOTH')
+  const [newCreating, setNewCreating]   = useState(false)
+  const searchTimeout                   = useRef(null)
+
+  function load() {
+    setLoading(true)
+    priceAlertService.list()
+      .then((res) => setAlerts(Array.isArray(res) ? res : (res.alerts ?? [])))
+      .catch(() => setAlerts([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  function openNew() {
+    setShowNew(true)
+    setNewSearch('')
+    setNewResults([])
+    setNewListing(null)
+    setNewCondition('ABOVE')
+    setNewThreshold('')
+    setNewNotifType('BOTH')
+  }
+
+  function handleSearchChange(val) {
+    setNewSearch(val)
+    setNewListing(null)
+    clearTimeout(searchTimeout.current)
+    if (!val.trim()) { setNewResults([]); return }
+    setNewSearchLoading(true)
+    searchTimeout.current = setTimeout(async () => {
+      try {
+        const res = await securitiesService.getListings({ ticker: val.trim(), pageSize: 8 })
+        setNewResults(res.items ?? [])
+      } catch { setNewResults([]) }
+      finally { setNewSearchLoading(false) }
+    }, 350)
+  }
+
+  async function handleCreate() {
+    if (!newListing || !newThreshold) return
+    setNewCreating(true)
+    try {
+      await priceAlertService.create({
+        listingId: newListing.id,
+        condition: newCondition,
+        threshold: Number(newThreshold),
+        notificationType: newNotifType,
+      })
+      addSuccess('Price alert created.')
+      setShowNew(false)
+      load()
+    } catch { /* error toast */ }
+    finally { setNewCreating(false) }
+  }
+
+  async function handleDelete(id) {
+    setDeleting((p) => ({ ...p, [id]: true }))
+    try {
+      await priceAlertService.delete(id)
+      setAlerts((p) => p.filter((a) => a.id !== id))
+      addSuccess('Alert deleted.')
+    } finally {
+      setDeleting((p) => ({ ...p, [id]: false }))
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-center justify-between mb-10">
+          <div>
+            <p className="text-xs tracking-widests uppercase text-violet-600 dark:text-violet-400 mb-1">Portal</p>
+            <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white">Price Alerts</h1>
+            <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mt-2" />
+          </div>
+          <button onClick={openNew} className="btn-primary text-xs px-5 py-2.5">
+            + New Alert
+          </button>
+        </div>
+
+        {/* New alert modal */}
+        {showNew && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowNew(false)}>
+            <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+              <div className="px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+                <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">New Price Alert</h2>
+              </div>
+              <div className="px-6 py-5 flex flex-col gap-4">
+                {/* Listing search */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Security</label>
+                  {newListing ? (
+                    <div className="flex items-center justify-between px-3 py-2 bg-violet-50 dark:bg-violet-900/20 rounded-lg">
+                      <span className="font-mono font-medium text-sm text-violet-700 dark:text-violet-400">{newListing.ticker}</span>
+                      <button onClick={() => { setNewListing(null); setNewSearch('') }} className="text-xs text-slate-400 hover:text-slate-600">✕</button>
+                    </div>
+                  ) : (
+                    <>
+                      <input
+                        type="text"
+                        value={newSearch}
+                        onChange={(e) => handleSearchChange(e.target.value)}
+                        className="input-field w-full"
+                        placeholder="Search ticker…"
+                        autoFocus
+                      />
+                      <div className="mt-1 flex flex-col gap-0.5 max-h-40 overflow-y-auto">
+                        {newSearchLoading && <p className="text-xs text-slate-400 py-1 text-center">Searching…</p>}
+                        {!newSearchLoading && newResults.length === 0 && newSearch.trim() && (
+                          <p className="text-xs text-slate-400 py-1 text-center">No results.</p>
+                        )}
+                        {newResults.map((l) => (
+                          <button key={l.id} onClick={() => setNewListing(l)} className="flex items-center justify-between px-2 py-1.5 rounded hover:bg-violet-50 dark:hover:bg-violet-900/20 text-left">
+                            <span className="font-mono text-sm text-violet-700 dark:text-violet-400 font-medium">{l.ticker}</span>
+                            <span className="text-xs text-slate-500 ml-2 truncate">{l.name}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                {/* Condition */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Condition</label>
+                  <select value={newCondition} onChange={(e) => setNewCondition(e.target.value)} className="input-field w-full">
+                    <option value="ABOVE">Price Above</option>
+                    <option value="BELOW">Price Below</option>
+                    <option value="CHANGE_PCT_UP">Change % Up</option>
+                    <option value="CHANGE_PCT_DOWN">Change % Down</option>
+                  </select>
+                </div>
+
+                {/* Threshold */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Threshold</label>
+                  <input
+                    type="number"
+                    value={newThreshold}
+                    onChange={(e) => setNewThreshold(e.target.value)}
+                    className="input-field w-full"
+                    placeholder="e.g. 150.00"
+                    min="0"
+                    step="0.01"
+                  />
+                </div>
+
+                {/* Notification type */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Notification</label>
+                  <select value={newNotifType} onChange={(e) => setNewNotifType(e.target.value)} className="input-field w-full">
+                    <option value="BOTH">Email + In-app</option>
+                    <option value="EMAIL">Email only</option>
+                    <option value="IN_APP">In-app only</option>
+                  </select>
+                </div>
+              </div>
+              <div className="px-6 pb-6 pt-2 border-t border-slate-100 dark:border-slate-800 flex justify-end gap-2">
+                <button onClick={() => setShowNew(false)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors rounded">Cancel</button>
+                <button
+                  onClick={handleCreate}
+                  disabled={newCreating || !newListing || !newThreshold}
+                  className="btn-primary text-xs px-4 py-2 disabled:opacity-50"
+                >
+                  {newCreating ? 'Creating…' : 'Create Alert'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Loading…</div>
+          ) : alerts.length === 0 ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">No price alerts. Click <strong>+ New Alert</strong> to create one.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Security', 'Condition', 'Threshold', 'Notification', 'Status', 'Date', ''].map((h) => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {alerts.map((a, i) => (
+                    <tr key={a.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                      <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{a.ticker ?? a.listing_id ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${CONDITION_BADGE[a.condition] ?? 'bg-slate-100 text-slate-600'}`}>
+                          {CONDITION_LABELS[a.condition] ?? a.condition}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 tabular-nums font-mono text-slate-700 dark:text-slate-300">
+                        {a.threshold != null ? fmt(a.threshold) : '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 text-xs px-2 py-0.5 rounded">
+                          {a.notification_type ?? '—'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        {a.triggered_at ? (
+                          <span className="inline-flex items-center gap-1 text-xs text-orange-600 dark:text-orange-400">
+                            <span className="w-1.5 h-1.5 rounded-full bg-orange-500 dark:bg-orange-400" />
+                            Triggered
+                          </span>
+                        ) : a.is_active ? (
+                          <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                            <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                            Active
+                          </span>
+                        ) : (
+                          <span className="text-xs text-slate-400">Inactive</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                        {a.created_at ? new Date(a.created_at).toLocaleDateString() : '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => handleDelete(a.id)}
+                          disabled={deleting[a.id]}
+                          className="text-xs text-red-500 hover:text-red-600 dark:hover:text-red-400 transition-colors disabled:opacity-50"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/client/ClientFundDetailPage.jsx
+++ b/src/pages/client/ClientFundDetailPage.jsx
@@ -54,6 +54,7 @@ export default function ClientFundDetailPage() {
   const [perfPeriod, setPerfPeriod]   = useState(PERF_PERIODS[0])
   const [perfData, setPerfData]       = useState([])
   const [perfLoading, setPerfLoading] = useState(true)
+  const [avgData, setAvgData]         = useState([])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -96,10 +97,15 @@ export default function ClientFundDetailPage() {
     setPerfLoading(true)
     const { from, to } = periodDates(period.months)
     try {
-      const data = await clientPortfolioService.getFundPerformance(id, from, to)
-      setPerfData(data)
+      const [perfResult, avgResult] = await Promise.allSettled([
+        clientPortfolioService.getFundPerformance(id, from, to),
+        clientPortfolioService.getAveragePerformance(from, to),
+      ])
+      setPerfData(perfResult.status === 'fulfilled' && Array.isArray(perfResult.value) ? perfResult.value : [])
+      setAvgData(avgResult.status === 'fulfilled' && Array.isArray(avgResult.value) ? avgResult.value : [])
     } catch {
       setPerfData([])
+      setAvgData([])
     } finally {
       setPerfLoading(false)
     }
@@ -167,6 +173,12 @@ export default function ClientFundDetailPage() {
           <StatCard label="Fund Value"        value={fmt(fund.fundValue ?? 0, 'RSD')} />
           <StatCard label="Profit"            value={`${(fund.profit ?? 0) >= 0 ? '+' : ''}${fmt(fund.profit ?? 0, 'RSD')}`} highlight={profitColor} />
           <StatCard label="Min. Contribution" value={fmt(fund.minimumContribution ?? 0, 'RSD')} />
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+          <StatCard label="Annual Return" value={fund.stats?.hasSufficientData ? `${(fund.stats.annualReturn * 100).toFixed(2)}%` : 'N/A'} />
+          <StatCard label="Volatility"    value={fund.stats?.hasSufficientData ? `${(fund.stats.volatility * 100).toFixed(2)}%` : 'N/A'} />
+          <StatCard label="Max Drawdown"  value={fund.stats?.hasSufficientData ? `${(fund.stats.maxDrawdown * 100).toFixed(2)}%` : 'N/A'} />
+          <StatCard label="R/V Ratio"     value={fund.stats?.hasSufficientData ? fund.stats.rewardToVariability.toFixed(3) : 'N/A'} />
         </div>
 
         {myPosition && (
@@ -258,7 +270,13 @@ export default function ClientFundDetailPage() {
           ) : (
             <ResponsiveContainer width="100%" height={240}>
               <LineChart
-                data={[...perfData].sort((a, b) => (a.date < b.date ? -1 : 1)).map(r => ({ date: String(r.date).slice(0, 10), value: r.value ?? 0 }))}
+                data={(() => {
+                  const avgMap = Object.fromEntries((avgData ?? []).map(r => [String(r.date).slice(0, 10), r.avgFundValue]))
+                  return [...perfData].sort((a, b) => (a.date < b.date ? -1 : 1)).map(r => {
+                    const d = String(r.date).slice(0, 10)
+                    return { date: d, value: r.value ?? 0, avgValue: avgMap[d] ?? null }
+                  })
+                })()}
                 margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
               >
                 <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
@@ -266,6 +284,7 @@ export default function ClientFundDetailPage() {
                 <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} tickLine={false} axisLine={false} tickFormatter={v => fmt(v)} width={80} />
                 <Tooltip formatter={v => [fmt(v), 'Value']} contentStyle={{ fontSize: 12, border: '1px solid #e2e8f0', borderRadius: 8, background: '#fff' }} />
                 <Line type="monotone" dataKey="value" stroke="#7c3aed" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                <Line type="monotone" dataKey="avgValue" stroke="#9ca3af" strokeWidth={1.5} strokeDasharray="5 5" dot={false} activeDot={false} name="Market Avg" />
               </LineChart>
             </ResponsiveContainer>
           )}

--- a/src/pages/client/ClientFundsDiscoveryPage.jsx
+++ b/src/pages/client/ClientFundsDiscoveryPage.jsx
@@ -55,10 +55,19 @@ export default function ClientFundsDiscoveryPage() {
     !search || f.name?.toLowerCase().includes(search.toLowerCase())
   )
 
+  const statsKeys = ['annualReturn', 'rewardToVariability', 'maxDrawdown', 'volatility']
+  function getVal(fund, col) {
+    if (statsKeys.includes(col)) {
+      if (!fund.stats?.hasSufficientData) return null
+      return fund.stats[col] ?? null
+    }
+    return fund[col] ?? null
+  }
+
   const sorted = [...filtered].sort((a, b) => {
     if (!sortCol) return 0
-    const va = a[sortCol]
-    const vb = b[sortCol]
+    const va = getVal(a, sortCol)
+    const vb = getVal(b, sortCol)
     if (va == null && vb == null) return 0
     if (va == null) return 1
     if (vb == null) return -1
@@ -115,6 +124,18 @@ export default function ClientFundsDiscoveryPage() {
                     <th className={thClass(true)} onClick={() => handleSort('minimumContribution')}>
                       Min. Contribution<SortIcon sortCol={sortCol} col="minimumContribution" sortOrder={sortOrder} />
                     </th>
+                    <th className={thClass(true)} onClick={() => handleSort('annualReturn')}>
+                      Annual Return<SortIcon sortCol={sortCol} col="annualReturn" sortOrder={sortOrder} />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('volatility')}>
+                      Volatility<SortIcon sortCol={sortCol} col="volatility" sortOrder={sortOrder} />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('maxDrawdown')}>
+                      Max Drawdown<SortIcon sortCol={sortCol} col="maxDrawdown" sortOrder={sortOrder} />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('rewardToVariability')}>
+                      R/V Ratio<SortIcon sortCol={sortCol} col="rewardToVariability" sortOrder={sortOrder} />
+                    </th>
                     <th className={thClass(false)}>Actions</th>
                   </tr>
                 </thead>
@@ -137,6 +158,18 @@ export default function ClientFundsDiscoveryPage() {
                           {(fund.profit ?? 0) >= 0 ? '+' : ''}{fmt(fund.profit ?? 0, 'RSD')}
                         </td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{fmt(fund.minimumContribution, 'RSD')}</td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? `${(fund.stats.annualReturn * 100).toFixed(2)}%` : 'N/A'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? `${(fund.stats.volatility * 100).toFixed(2)}%` : 'N/A'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? `${(fund.stats.maxDrawdown * 100).toFixed(2)}%` : 'N/A'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? fund.stats.rewardToVariability.toFixed(3) : 'N/A'}
+                        </td>
                         <td className="px-4 py-3">
                           <button onClick={() => setInvestModal(fund)} className="btn-primary text-xs px-3 py-1">Invest</button>
                         </td>

--- a/src/pages/client/ClientMyOrdersPage.jsx
+++ b/src/pages/client/ClientMyOrdersPage.jsx
@@ -1,0 +1,185 @@
+import { useEffect, useState } from 'react'
+import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { orderService } from '../../services/orderService'
+import { fmt } from '../../utils/formatting'
+
+const STATUS_FILTERS    = ['ALL', 'PENDING', 'APPROVED', 'DECLINED', 'DONE']
+const ASSET_TYPE_OPTIONS = ['', 'STOCK', 'FOREX', 'FUTURES', 'OPTION']
+const DIRECTION_OPTIONS  = ['', 'BUY', 'SELL']
+
+const STATUS_BADGE = {
+  PENDING:  'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  APPROVED: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  DECLINED: 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+  DONE:     'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
+  CANCELLED:'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400',
+}
+
+export default function ClientMyOrdersPage() {
+  const [orders, setOrders]         = useState([])
+  const [loading, setLoading]       = useState(true)
+  const [statusFilter, setStatus]   = useState('ALL')
+  const [assetType, setAssetType]   = useState('')
+  const [direction, setDirection]   = useState('')
+  const [fromDate, setFromDate]     = useState('')
+  const [toDate, setToDate]         = useState('')
+  const [page, setPage]             = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const PAGE_SIZE = 20
+
+  function load(p = page) {
+    setLoading(true)
+    orderService.getClientOrders({
+      status:    statusFilter === 'ALL' ? '' : statusFilter,
+      assetType,
+      direction,
+      fromDate,
+      toDate,
+      page:     p,
+      pageSize: PAGE_SIZE,
+    })
+      .then((res) => {
+        const items = Array.isArray(res) ? res : (res.orders ?? res.items ?? [])
+        setOrders(items)
+        setTotalPages(res.total_pages ?? 1)
+      })
+      .catch(() => setOrders([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { setPage(1); load(1) }, [statusFilter, assetType, direction, fromDate, toDate])
+
+  function handlePage(next) { setPage(next); load(next) }
+
+  function effectiveStatus(o) {
+    if (o.is_done ?? o.isDone) return 'DONE'
+    return o.status ?? '—'
+  }
+
+  return (
+    <ClientPortalLayout>
+      <div className="p-6 max-w-7xl mx-auto">
+        <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white mb-1">My Orders</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">Your order history</p>
+
+        {/* Status pills */}
+        <div className="flex gap-2 mb-4 flex-wrap">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f}
+              onClick={() => setStatus(f)}
+              className={`px-4 py-1.5 text-xs tracking-widest uppercase rounded-full transition-colors ${
+                statusFilter === f
+                  ? 'bg-violet-600 text-white'
+                  : 'bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:border-violet-400'
+              }`}
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+
+        {/* Extra filters */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 mb-6 shadow-sm">
+          <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Asset Type</label>
+              <select value={assetType} onChange={(e) => setAssetType(e.target.value)} className="input-field w-full">
+                {ASSET_TYPE_OPTIONS.map((t) => <option key={t} value={t}>{t || 'All'}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Direction</label>
+              <select value={direction} onChange={(e) => setDirection(e.target.value)} className="input-field w-full">
+                {DIRECTION_OPTIONS.map((d) => <option key={d} value={d}>{d || 'All'}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">From</label>
+              <input type="date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} className="input-field w-full" />
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">To</label>
+              <input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)} className="input-field w-full" />
+            </div>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Loading…</div>
+          ) : orders.length === 0 ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">No orders found.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Tip', 'Hartija', 'Smer', 'Količina', 'Cijena', 'Status', 'Datum', 'Komisija'].map((h) => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {orders.map((o, i) => {
+                    const sl = effectiveStatus(o)
+                    const ticker = o.ticker ?? o.asset_ticker ?? o.asset_id ?? '—'
+                    const atype  = o.asset_type ?? '—'
+                    return (
+                      <tr key={o.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                        <td className="px-4 py-3">
+                          <span className="bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 text-xs px-2 py-0.5 rounded font-mono">
+                            {o.order_type ?? o.orderType ?? '—'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className="font-mono font-medium text-slate-900 dark:text-white">{ticker}</span>
+                          {' '}
+                          <span className="bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 text-xs px-1.5 py-0.5 rounded">{atype}</span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${
+                            o.direction === 'BUY'
+                              ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                              : 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400'
+                          }`}>
+                            {o.direction}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{o.quantity}</td>
+                        <td className="px-4 py-3 tabular-nums font-mono text-slate-700 dark:text-slate-300">
+                          {o.price_per_unit != null ? fmt(o.price_per_unit) : '—'}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium tracking-wide rounded-full ${STATUS_BADGE[sl] ?? STATUS_BADGE.DONE}`}>
+                            {sl}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                          {o.last_modification ? new Date(o.last_modification).toLocaleDateString() : '—'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">
+                          {o.commission_paid != null ? fmt(o.commission_paid) : '—'}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {totalPages > 1 && (
+            <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+              <span>Page {page} of {totalPages}</span>
+              <div className="flex gap-2">
+                <button onClick={() => handlePage(page - 1)} disabled={page <= 1} className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-40 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors">Prev</button>
+                <button onClick={() => handlePage(page + 1)} disabled={page >= totalPages} className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-40 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors">Next</button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/client/ClientOtcNegotiationDetailPage.jsx
+++ b/src/pages/client/ClientOtcNegotiationDetailPage.jsx
@@ -49,7 +49,13 @@ export default function ClientOtcNegotiationDetailPage() {
   const [selectedAccountId, setSelectedAccountId] = useState('')
   const [accountsLoading,   setAccountsLoading]   = useState(false)
 
+  const [history, setHistory] = useState([])
+
   const negRef = useRef(null)
+
+  useEffect(() => {
+    clientOtcService.getNegotiationHistory(id).then(setHistory).catch(() => {})
+  }, [id])
 
   useEffect(() => {
     setLoading(true)
@@ -419,6 +425,68 @@ export default function ClientOtcNegotiationDetailPage() {
           </>
         )}
       </div>
+
+      {history.length > 0 && (
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm p-6 mb-6">
+          <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 mb-4">Negotiation History</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 dark:border-slate-700">
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Action</th>
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">By</th>
+                  <th className="px-3 py-2 text-right text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Amount</th>
+                  <th className="px-3 py-2 text-right text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Price/Stock</th>
+                  <th className="px-3 py-2 text-right text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Premium</th>
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Settlement</th>
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Timestamp</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {history.map(e => {
+                  const badge = {
+                    CREATED:      'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+                    COUNTER_OFFER:'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+                    ACCEPTED:     'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+                    REJECTED:     'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+                  }[e.action] ?? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'
+                  const fmtChange = (oldVal, newVal) =>
+                    oldVal != null && newVal != null && String(oldVal) !== String(newVal)
+                      ? <span><span className="line-through text-slate-400">{oldVal}</span><span className="mx-1 text-slate-400">→</span>{newVal}</span>
+                      : (newVal ?? oldVal ?? <span className="text-slate-400">—</span>)
+                  return (
+                    <tr key={e.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
+                      <td className="px-3 py-3">
+                        <span className={`inline-block text-xs font-semibold px-2 py-0.5 rounded ${badge}`}>
+                          {e.action.replace('_', ' ')}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3 text-slate-700 dark:text-slate-300">
+                        {e.actorName || `${e.actorType} #${e.actorId}`}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldAmount, e.newAmount)}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldPricePerStock, e.newPricePerStock)}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldPremium, e.newPremium)}
+                      </td>
+                      <td className="px-3 py-3 text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldSettlementDate, e.newSettlementDate)}
+                      </td>
+                      <td className="px-3 py-3 text-slate-500 dark:text-slate-400 text-xs">
+                        {e.timestamp ? new Date(e.timestamp).toLocaleString() : '—'}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </ClientPortalLayout>
   )
 }

--- a/src/pages/client/ClientPortfolioPage.jsx
+++ b/src/pages/client/ClientPortfolioPage.jsx
@@ -4,12 +4,14 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import ClientPortalLayout from '../../layouts/ClientPortalLayout'
 import { clientPortfolioService } from '../../services/clientPortfolioService'
 import { clientAccountService } from '../../services/clientAccountService'
+import { clientDividendService } from '../../services/dividendService'
 import { fmt, fundErrorMessage } from '../../utils/formatting'
 
 const TABS = [
   { label: 'All Securities',    key: 'all' },
   { label: 'Public Securities', key: 'public' },
   { label: 'My Funds',         key: 'funds' },
+  { label: 'Dividends',        key: 'dividends' },
 ]
 
 function TypeBadge({ type }) {
@@ -314,6 +316,27 @@ export default function ClientPortfolioPage() {
     if (activeTab.key === 'funds') loadMyFunds()
   }, [activeTab.key, loadMyFunds])
 
+  const [dividends, setDividends]         = useState([])
+  const [dividendsLoading, setDivLoading] = useState(false)
+  const [dividendsError, setDivError]     = useState(null)
+
+  const loadDividends = useCallback(async () => {
+    setDivLoading(true)
+    setDivError(null)
+    try {
+      const res = await clientDividendService.getMyDividends()
+      setDividends(Array.isArray(res) ? res : (res.dividends ?? res.payouts ?? []))
+    } catch {
+      setDivError(true)
+    } finally {
+      setDivLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (activeTab.key === 'dividends') loadDividends()
+  }, [activeTab.key, loadDividends])
+
   const displayed = activeTab.key === 'public'
     ? holdings.filter(h => h.is_public)
     : holdings
@@ -424,8 +447,46 @@ export default function ClientPortfolioPage() {
           </div>
         )}
 
+        {/* ── Dividende tab ── */}
+        {activeTab.key === 'dividends' && (
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+            {dividendsLoading ? (
+              <div className="flex items-center justify-center py-20"><p className="text-slate-500 text-sm">Loading dividends…</p></div>
+            ) : dividendsError ? (
+              <div className="flex items-center justify-center py-20"><p className="text-red-500 text-sm">Failed to load dividends.</p></div>
+            ) : dividends.length === 0 ? (
+              <div className="flex items-center justify-center py-20"><p className="text-slate-400 text-sm">No dividend payouts yet.</p></div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-200 dark:border-slate-700">
+                      {['Ticker', 'Date', 'Quantity', 'Gross Amount', 'Tax (RSD)', 'Net Amount', 'Currency'].map(h => (
+                        <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dividends.map((d, i) => (
+                      <tr key={d.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                        <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{d.ticker ?? d.stock_listing_id ?? '—'}</td>
+                        <td className="px-4 py-3 text-xs text-slate-500 whitespace-nowrap">{d.payment_date ?? '—'}</td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{d.quantity != null ? Number(d.quantity).toFixed(4) : '—'}</td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{d.gross_amount != null ? fmt(d.gross_amount) : '—'}</td>
+                        <td className="px-4 py-3 tabular-nums text-amber-600 dark:text-amber-400">{d.tax_rsd != null ? fmt(d.tax_rsd) : '—'}</td>
+                        <td className="px-4 py-3 tabular-nums font-medium text-emerald-600 dark:text-emerald-400">{d.net_amount != null ? fmt(d.net_amount) : '—'}</td>
+                        <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{d.currency ?? '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* ── Securities tabs ── */}
-        {activeTab.key !== 'funds' && (
+        {activeTab.key !== 'funds' && activeTab.key !== 'dividends' && (
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
             {loading ? (
               <div className="flex items-center justify-center py-20">

--- a/src/pages/client/ClientPriceAlertsPage.jsx
+++ b/src/pages/client/ClientPriceAlertsPage.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { useApiError } from '../../context/ApiErrorContext'
+import { clientPriceAlertService } from '../../services/priceAlertService'
+import { fmt } from '../../utils/formatting'
+
+const CONDITION_LABELS = {
+  ABOVE:           'Above',
+  BELOW:           'Below',
+  CHANGE_PCT_UP:   '% Up',
+  CHANGE_PCT_DOWN: '% Down',
+}
+
+const CONDITION_BADGE = {
+  ABOVE:           'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  BELOW:           'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+  CHANGE_PCT_UP:   'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  CHANGE_PCT_DOWN: 'bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+}
+
+export default function ClientPriceAlertsPage() {
+  const { addSuccess } = useApiError()
+  const [alerts, setAlerts]   = useState([])
+  const [loading, setLoading] = useState(true)
+  const [deleting, setDeleting] = useState({})
+
+  useEffect(() => {
+    setLoading(true)
+    clientPriceAlertService.list()
+      .then((res) => setAlerts(Array.isArray(res) ? res : (res.alerts ?? [])))
+      .catch(() => setAlerts([]))
+      .finally(() => setLoading(false))
+  }, [])
+
+  async function handleDelete(id) {
+    setDeleting((p) => ({ ...p, [id]: true }))
+    try {
+      await clientPriceAlertService.delete(id)
+      setAlerts((p) => p.filter((a) => a.id !== id))
+      addSuccess('Alert deleted.')
+    } finally {
+      setDeleting((p) => ({ ...p, [id]: false }))
+    }
+  }
+
+  return (
+    <ClientPortalLayout>
+      <div className="p-6 max-w-6xl mx-auto">
+        <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white mb-1">Price Alerts</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">Vaše cjenovne notifikacije</p>
+
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Loading…</div>
+          ) : alerts.length === 0 ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">No price alerts. Set one on a listing detail page.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Hartija', 'Uslov', 'Prag', 'Notifikacija', 'Status', 'Datum', ''].map((h) => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {alerts.map((a, i) => (
+                    <tr key={a.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                      <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{a.ticker ?? a.listing_id ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${CONDITION_BADGE[a.condition] ?? 'bg-slate-100 text-slate-600'}`}>
+                          {CONDITION_LABELS[a.condition] ?? a.condition}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 tabular-nums font-mono text-slate-700 dark:text-slate-300">{a.threshold != null ? fmt(a.threshold) : '—'}</td>
+                      <td className="px-4 py-3"><span className="bg-slate-100 dark:bg-slate-800 text-slate-500 text-xs px-2 py-0.5 rounded">{a.notification_type ?? '—'}</span></td>
+                      <td className="px-4 py-3">
+                        {a.triggered_at ? (
+                          <span className="text-xs text-orange-600 dark:text-orange-400">Triggered</span>
+                        ) : a.is_active ? (
+                          <span className="text-xs text-emerald-600 dark:text-emerald-400">Active</span>
+                        ) : (
+                          <span className="text-xs text-slate-400">Inactive</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-slate-500 whitespace-nowrap">{a.created_at ? new Date(a.created_at).toLocaleDateString() : '—'}</td>
+                      <td className="px-4 py-3">
+                        <button onClick={() => handleDelete(a.id)} disabled={deleting[a.id]} className="text-xs text-red-500 hover:text-red-600 transition-colors disabled:opacity-50">Delete</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/client/ClientRecurringOrdersPage.jsx
+++ b/src/pages/client/ClientRecurringOrdersPage.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { useApiError } from '../../context/ApiErrorContext'
+import { clientRecurringOrderService } from '../../services/recurringOrderService'
+import { fmt } from '../../utils/formatting'
+
+const CADENCE_LABELS = { DAILY: 'Dnevno', WEEKLY: 'Sedmično', MONTHLY: 'Mesečno' }
+const MODE_LABELS    = { BY_QUANTITY: 'Po količini', BY_AMOUNT: 'Po iznosu' }
+
+export default function ClientRecurringOrdersPage() {
+  const { addSuccess } = useApiError()
+  const [orders, setOrders]   = useState([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy]       = useState({})
+
+  function load() {
+    setLoading(true)
+    clientRecurringOrderService.list()
+      .then((res) => setOrders(Array.isArray(res) ? res : (res.recurring_orders ?? res.orders ?? [])))
+      .catch(() => setOrders([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function handlePause(id) {
+    setBusy((p) => ({ ...p, [id]: true }))
+    try {
+      await clientRecurringOrderService.pause(id)
+      setOrders((p) => p.map((o) => o.id === id ? { ...o, active: false } : o))
+      addSuccess('Recurring order paused.')
+    } finally { setBusy((p) => ({ ...p, [id]: false })) }
+  }
+
+  async function handleResume(id) {
+    setBusy((p) => ({ ...p, [id]: true }))
+    try {
+      await clientRecurringOrderService.resume(id)
+      setOrders((p) => p.map((o) => o.id === id ? { ...o, active: true } : o))
+      addSuccess('Recurring order resumed.')
+    } finally { setBusy((p) => ({ ...p, [id]: false })) }
+  }
+
+  async function handleCancel(id) {
+    if (!window.confirm('Cancel this recurring order?')) return
+    setBusy((p) => ({ ...p, [id]: true }))
+    try {
+      await clientRecurringOrderService.cancel(id)
+      setOrders((p) => p.filter((o) => o.id !== id))
+      addSuccess('Recurring order cancelled.')
+    } finally { setBusy((p) => ({ ...p, [id]: false })) }
+  }
+
+  return (
+    <ClientPortalLayout>
+      <div className="p-6 max-w-7xl mx-auto">
+        <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white mb-1">Recurring Orders</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">Vaši trajni nalozi</p>
+
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Loading…</div>
+          ) : orders.length === 0 ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Nema trajnih naloga.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Hartija', 'Smer', 'Način / Vrednost', 'Učestalost', 'Sledeće', 'Status', 'Akcije'].map((h) => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {orders.map((o, i) => (
+                    <tr key={o.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                      <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{o.ticker ?? o.asset_id ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${
+                          o.direction === 'BUY'
+                            ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                            : 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400'
+                        }`}>{o.direction}</span>
+                      </td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{MODE_LABELS[o.mode] ?? o.mode} — {fmt(o.value)}</td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{CADENCE_LABELS[o.cadence] ?? o.cadence}</td>
+                      <td className="px-4 py-3 text-xs text-slate-500 whitespace-nowrap">{o.next_run ? new Date(o.next_run).toLocaleString() : '—'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`text-xs font-medium ${o.active ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-400'}`}>
+                          {o.active ? 'Aktivan' : 'Pauziran'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex gap-2">
+                          {o.active ? (
+                            <button onClick={() => handlePause(o.id)} disabled={busy[o.id]} className="px-3 py-1 text-xs rounded border border-yellow-400 text-yellow-700 dark:text-yellow-400 hover:bg-yellow-50 dark:hover:bg-yellow-900/20 transition-colors disabled:opacity-50">Pause</button>
+                          ) : (
+                            <button onClick={() => handleResume(o.id)} disabled={busy[o.id]} className="px-3 py-1 text-xs rounded border border-emerald-400 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors disabled:opacity-50">Resume</button>
+                          )}
+                          <button onClick={() => handleCancel(o.id)} disabled={busy[o.id]} className="px-3 py-1 text-xs rounded border border-red-300 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50">Cancel</button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/client/ClientWatchlistPage.jsx
+++ b/src/pages/client/ClientWatchlistPage.jsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import ClientPortalLayout from '../../layouts/ClientPortalLayout'
+import { useApiError } from '../../context/ApiErrorContext'
+import { clientWatchlistService } from '../../services/watchlistService'
+import { fmt } from '../../utils/formatting'
+
+export default function ClientWatchlistPage() {
+  const navigate = useNavigate()
+  const { addSuccess } = useApiError()
+
+  const [watchlists, setWatchlists]   = useState([])
+  const [loading, setLoading]         = useState(true)
+  const [expanded, setExpanded]       = useState({})
+  const [items, setItems]             = useState({})
+  const [loadingItems, setLoadingItems] = useState({})
+  const [showCreate, setShowCreate]   = useState(false)
+  const [newName, setNewName]         = useState('')
+  const [creating, setCreating]       = useState(false)
+
+  function load() {
+    setLoading(true)
+    clientWatchlistService.listWatchlists()
+      .then((res) => setWatchlists(Array.isArray(res) ? res : (res.watchlists ?? [])))
+      .catch(() => setWatchlists([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function toggleExpand(wl) {
+    const id = wl.id
+    if (expanded[id]) { setExpanded((p) => ({ ...p, [id]: false })); return }
+    setExpanded((p) => ({ ...p, [id]: true }))
+    if (items[id]) return
+    setLoadingItems((p) => ({ ...p, [id]: true }))
+    try {
+      const res = await clientWatchlistService.getItems(id)
+      setItems((p) => ({ ...p, [id]: Array.isArray(res) ? res : (res.items ?? []) }))
+    } catch {
+      setItems((p) => ({ ...p, [id]: [] }))
+    } finally {
+      setLoadingItems((p) => ({ ...p, [id]: false }))
+    }
+  }
+
+  async function handleDelete(id) {
+    if (!window.confirm('Delete this watchlist?')) return
+    try {
+      await clientWatchlistService.deleteWatchlist(id)
+      setWatchlists((p) => p.filter((w) => w.id !== id))
+      addSuccess('Watchlist deleted.')
+    } catch { }
+  }
+
+  async function handleRemoveItem(watchlistId, listingId) {
+    try {
+      await clientWatchlistService.removeItem(watchlistId, listingId)
+      setItems((p) => ({ ...p, [watchlistId]: (p[watchlistId] ?? []).filter((i) => i.listing_id !== listingId) }))
+      addSuccess('Removed from watchlist.')
+    } catch { }
+  }
+
+  async function handleCreate() {
+    if (!newName.trim()) return
+    setCreating(true)
+    try {
+      await clientWatchlistService.createWatchlist(newName.trim())
+      setNewName(''); setShowCreate(false); load()
+      addSuccess('Watchlist created.')
+    } finally { setCreating(false) }
+  }
+
+  return (
+    <ClientPortalLayout>
+      <div className="p-6 max-w-5xl mx-auto">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="font-serif text-2xl font-light text-slate-900 dark:text-white mb-1">Watchlists</h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Vaše praćene hartije</p>
+          </div>
+          <button onClick={() => setShowCreate(true)} className="btn-primary text-xs px-4 py-2">+ Nova</button>
+        </div>
+
+        {showCreate && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowCreate(false)}>
+            <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+              <div className="px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+                <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">Nova watchlista</h2>
+              </div>
+              <div className="px-6 py-5">
+                <input type="text" value={newName} onChange={(e) => setNewName(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleCreate()} className="input-field w-full" placeholder="Naziv…" autoFocus />
+              </div>
+              <div className="px-6 pb-6 pt-2 border-t border-slate-100 dark:border-slate-800 flex justify-end gap-2">
+                <button onClick={() => setShowCreate(false)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors">Odustani</button>
+                <button onClick={handleCreate} disabled={creating || !newName.trim()} className="btn-primary text-xs px-4 py-2 disabled:opacity-50">{creating ? 'Kreiranje…' : 'Kreiraj'}</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-center text-slate-400 text-sm py-12">Loading…</div>
+        ) : watchlists.length === 0 ? (
+          <div className="text-center text-slate-400 text-sm py-12">Nema watchlista.</div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {watchlists.map((wl) => (
+              <div key={wl.id} className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+                <div className="flex items-center justify-between px-5 py-4">
+                  <button onClick={() => toggleExpand(wl)} className="flex items-center gap-3 text-left flex-1">
+                    <svg className={`w-4 h-4 text-slate-400 transition-transform ${expanded[wl.id] ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5l7 7-7 7" />
+                    </svg>
+                    <span className="font-medium text-slate-900 dark:text-white">{wl.name}</span>
+                  </button>
+                  <button onClick={() => handleDelete(wl.id)} className="text-xs text-red-500 hover:text-red-600 transition-colors">Delete</button>
+                </div>
+                {expanded[wl.id] && (
+                  <div className="border-t border-slate-100 dark:border-slate-800">
+                    {loadingItems[wl.id] ? (
+                      <div className="px-5 py-4 text-sm text-slate-400">Loading…</div>
+                    ) : (items[wl.id] ?? []).length === 0 ? (
+                      <div className="px-5 py-4 text-sm text-slate-400">No items.</div>
+                    ) : (
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b border-slate-100 dark:border-slate-800">
+                            {['Ticker', 'Naziv', 'Cijena', 'Promjena', ''].map((h) => (
+                              <th key={h} className="px-4 py-3 text-left text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 font-medium">{h}</th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {(items[wl.id] ?? []).map((item, i) => {
+                            const changePct = item.change_percent ?? (item.change && item.price ? (item.change / item.price * 100) : null)
+                            return (
+                              <tr key={item.id ?? item.listing_id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                                <td className="px-4 py-3 font-mono font-medium text-violet-600 dark:text-violet-400 cursor-pointer hover:underline" onClick={() => navigate(`/client/securities/${item.listing_id}`)}>{item.ticker ?? '—'}</td>
+                                <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{item.name ?? '—'}</td>
+                                <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{item.price != null ? fmt(item.price) : '—'}</td>
+                                <td className={`px-4 py-3 tabular-nums font-medium ${changePct == null ? '' : changePct >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500 dark:text-red-400'}`}>
+                                  {changePct != null ? `${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%` : '—'}
+                                </td>
+                                <td className="px-4 py-3">
+                                  <button onClick={() => handleRemoveItem(wl.id, item.listing_id)} className="text-xs text-red-500 hover:text-red-600 transition-colors">Remove</button>
+                                </td>
+                              </tr>
+                            )
+                          })}
+                        </tbody>
+                      </table>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ClientPortalLayout>
+  )
+}

--- a/src/pages/employee/AuditLogPage.jsx
+++ b/src/pages/employee/AuditLogPage.jsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { usePermission } from '../../hooks/usePermission'
+import { auditService } from '../../services/auditService'
+
+const ACTION_OPTIONS = [
+  '', 'ORDER_APPROVED', 'ORDER_DECLINED', 'LIMIT_CHANGE', 'RESET_USED_LIMIT',
+  'PERMISSION_CHANGE', 'MANUAL_TAX',
+]
+
+const ACTION_BADGE = {
+  ORDER_APPROVED:   'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  ORDER_DECLINED:   'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+  LIMIT_CHANGE:     'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  RESET_USED_LIMIT: 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  PERMISSION_CHANGE:'bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400',
+  MANUAL_TAX:       'bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+}
+
+export default function AuditLogPage() {
+  useWindowTitle('Audit Log | AnkaBanka')
+  const { canAny } = usePermission()
+  if (!canAny(['isSupervisor', 'isAdmin'])) return <Navigate to="/" replace />
+
+  const [logs, setLogs]           = useState([])
+  const [loading, setLoading]     = useState(true)
+  const [actionFilter, setAction] = useState('')
+  const [actorId, setActorId]     = useState('')
+  const [fromDate, setFromDate]   = useState('')
+  const [toDate, setToDate]       = useState('')
+  const [page, setPage]           = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const PAGE_SIZE = 20
+
+  function load(p = page) {
+    setLoading(true)
+    auditService.getAuditLogs({
+      action:   actionFilter,
+      actorId:  actorId ? Number(actorId) : undefined,
+      fromDate,
+      toDate,
+      page:     p,
+      pageSize: PAGE_SIZE,
+    })
+      .then((res) => {
+        const items = Array.isArray(res) ? res : (res.logs ?? res.items ?? [])
+        setLogs(items)
+        setTotalPages(res.total_pages ?? 1)
+      })
+      .catch(() => setLogs([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { setPage(1); load(1) }, [actionFilter, actorId, fromDate, toDate])
+
+  function handlePage(next) { setPage(next); load(next) }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Supervisor Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-1">Audit Log</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-10" />
+
+        {/* Filters */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 mb-6 shadow-sm">
+          <p className="text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 mb-4">Filters</p>
+          <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Action</label>
+              <select value={actionFilter} onChange={(e) => setAction(e.target.value)} className="input-field w-full">
+                {ACTION_OPTIONS.map((a) => <option key={a} value={a}>{a || 'All'}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Actor ID</label>
+              <input type="number" value={actorId} onChange={(e) => setActorId(e.target.value)} placeholder="Employee ID…" className="input-field w-full" />
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">From</label>
+              <input type="date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} className="input-field w-full" />
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">To</label>
+              <input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)} className="input-field w-full" />
+            </div>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Loading…</div>
+          ) : logs.length === 0 ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">No audit events found.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Vreme', 'Izvršio', 'Akcija', 'Cilj', 'Stara vrednost', 'Nova vrednost'].map((h) => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {logs.map((log, i) => (
+                    <tr key={log.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                      <td className="px-4 py-3 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                        {log.timestamp ? new Date(log.timestamp).toLocaleString() : '—'}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <span className="font-medium text-slate-900 dark:text-white">{log.actor_name ?? log.actor_id ?? '—'}</span>
+                        {log.actor_type && (
+                          <span className="ml-1.5 text-xs text-slate-400 dark:text-slate-500">{log.actor_type}</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${ACTION_BADGE[log.action] ?? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'}`}>
+                          {log.action ?? '—'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-slate-600 dark:text-slate-400 whitespace-nowrap">
+                        {log.target_name ?? (log.target_id ? `#${log.target_id}` : '—')}
+                        {log.target_type && <span className="ml-1 text-xs text-slate-400">({log.target_type})</span>}
+                      </td>
+                      <td className="px-4 py-3 text-xs font-mono text-slate-600 dark:text-slate-400 max-w-[160px] truncate" title={log.old_value}>
+                        {log.old_value ?? '—'}
+                      </td>
+                      <td className="px-4 py-3 text-xs font-mono text-slate-600 dark:text-slate-400 max-w-[160px] truncate" title={log.new_value}>
+                        {log.new_value ?? '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {totalPages > 1 && (
+            <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+              <span>Page {page} of {totalPages}</span>
+              <div className="flex gap-2">
+                <button onClick={() => handlePage(page - 1)} disabled={page <= 1} className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-40 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors">Prev</button>
+                <button onClick={() => handlePage(page + 1)} disabled={page >= totalPages} className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-40 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors">Next</button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/investment/FundDetailPage.jsx
+++ b/src/pages/investment/FundDetailPage.jsx
@@ -116,6 +116,7 @@ export default function FundDetailPage() {
   const [perfPeriod, setPerfPeriod]   = useState(PERF_PERIODS[0])
   const [perfData, setPerfData]       = useState([])
   const [perfLoading, setPerfLoading] = useState(true)
+  const [avgData, setAvgData]         = useState([])
 
   const isSupervisor = user?.permissions?.isSupervisor
   const isAgent      = user?.permissions?.isAgent
@@ -151,10 +152,15 @@ export default function FundDetailPage() {
     setPerfLoading(true)
     const { from, to } = periodDates(period.months)
     try {
-      const data = await fundService.getFundPerformance(id, from, to)
-      setPerfData(Array.isArray(data) ? data : [])
+      const [perfResult, avgResult] = await Promise.allSettled([
+        fundService.getFundPerformance(id, from, to),
+        fundService.getAveragePerformance(from, to),
+      ])
+      setPerfData(perfResult.status === 'fulfilled' && Array.isArray(perfResult.value) ? perfResult.value : [])
+      setAvgData(avgResult.status === 'fulfilled' && Array.isArray(avgResult.value) ? avgResult.value : [])
     } catch {
       setPerfData([])
+      setAvgData([])
     } finally {
       setPerfLoading(false)
     }
@@ -217,11 +223,17 @@ export default function FundDetailPage() {
         </div>
 
         {/* Stat cards */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
           <StatCard label="Fund Value"        value={fmt(fund.fundValue        ?? 0, 'RSD')} />
           <StatCard label="Liquid Assets"     value={fmt(fund.liquidAssets     ?? 0, 'RSD')} />
           <StatCard label="Profit"            value={`${(fund.profit ?? 0) >= 0 ? '+' : ''}${fmt(fund.profit ?? 0, 'RSD')}`} highlight={profitColor} />
           <StatCard label="Min. Contribution" value={fmt(fund.minimumContribution ?? 0, 'RSD')} />
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          <StatCard label="Annual Return"       value={fund.stats?.hasSufficientData ? `${(fund.stats.annualReturn * 100).toFixed(2)}%` : 'N/A'} />
+          <StatCard label="Volatility"          value={fund.stats?.hasSufficientData ? `${(fund.stats.volatility * 100).toFixed(2)}%` : 'N/A'} />
+          <StatCard label="Max Drawdown"        value={fund.stats?.hasSufficientData ? `${(fund.stats.maxDrawdown * 100).toFixed(2)}%` : 'N/A'} />
+          <StatCard label="R/V Ratio"           value={fund.stats?.hasSufficientData ? fund.stats.rewardToVariability.toFixed(3) : 'N/A'} />
         </div>
 
         {/* Action buttons */}
@@ -326,7 +338,13 @@ export default function FundDetailPage() {
           ) : (
             <ResponsiveContainer width="100%" height={240}>
               <LineChart
-                data={[...perfData].sort((a, b) => (a.date < b.date ? -1 : 1)).map(r => ({ date: String(r.date).slice(0, 10), value: r.fundValue ?? 0 }))}
+                data={(() => {
+                  const avgMap = Object.fromEntries((avgData ?? []).map(r => [String(r.date).slice(0, 10), r.avgFundValue]))
+                  return [...perfData].sort((a, b) => (a.date < b.date ? -1 : 1)).map(r => {
+                    const d = String(r.date).slice(0, 10)
+                    return { date: d, value: r.fundValue ?? 0, avgValue: avgMap[d] ?? null }
+                  })
+                })()}
                 margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
               >
                 <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
@@ -334,6 +352,7 @@ export default function FundDetailPage() {
                 <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} tickLine={false} axisLine={false} tickFormatter={v => fmt(v)} width={80} />
                 <Tooltip formatter={v => [fmt(v), 'Value']} contentStyle={{ fontSize: 12, border: '1px solid #e2e8f0', borderRadius: 8, background: '#fff' }} />
                 <Line type="monotone" dataKey="value" stroke="#7c3aed" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                <Line type="monotone" dataKey="avgValue" stroke="#9ca3af" strokeWidth={1.5} strokeDasharray="5 5" dot={false} activeDot={false} name="Market Avg" />
               </LineChart>
             </ResponsiveContainer>
           )}

--- a/src/pages/investment/FundsDiscoveryPage.jsx
+++ b/src/pages/investment/FundsDiscoveryPage.jsx
@@ -60,10 +60,19 @@ export default function FundsDiscoveryPage() {
     !search || f.name?.toLowerCase().includes(search.toLowerCase())
   )
 
+  const statsKeys = ['annualReturn', 'rewardToVariability', 'maxDrawdown', 'volatility']
+  function getVal(fund, col) {
+    if (statsKeys.includes(col)) {
+      if (!fund.stats?.hasSufficientData) return null
+      return fund.stats[col] ?? null
+    }
+    return fund[col] ?? null
+  }
+
   const sorted = [...filtered].sort((a, b) => {
     if (!sortCol) return 0
-    const va = a[sortCol]
-    const vb = b[sortCol]
+    const va = getVal(a, sortCol)
+    const vb = getVal(b, sortCol)
     if (va == null && vb == null) return 0
     if (va == null) return 1
     if (vb == null) return -1
@@ -125,6 +134,18 @@ export default function FundsDiscoveryPage() {
                     <th className={thClass(true)} onClick={() => handleSort('minimumContribution')}>
                       Min. Contribution<SortIcon sortCol={sortCol} col="minimumContribution" sortOrder={sortOrder} />
                     </th>
+                    <th className={thClass(true)} onClick={() => handleSort('annualReturn')}>
+                      Annual Return<SortIcon sortCol={sortCol} col="annualReturn" sortOrder={sortOrder} />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('volatility')}>
+                      Volatility<SortIcon sortCol={sortCol} col="volatility" sortOrder={sortOrder} />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('maxDrawdown')}>
+                      Max Drawdown<SortIcon sortCol={sortCol} col="maxDrawdown" sortOrder={sortOrder} />
+                    </th>
+                    <th className={thClass(true)} onClick={() => handleSort('rewardToVariability')}>
+                      R/V Ratio<SortIcon sortCol={sortCol} col="rewardToVariability" sortOrder={sortOrder} />
+                    </th>
                     {(isAgent || isSupervisor) && <th className={thClass(false)}>Actions</th>}
                   </tr>
                 </thead>
@@ -147,6 +168,18 @@ export default function FundsDiscoveryPage() {
                           {(fund.profit ?? 0) >= 0 ? '+' : ''}{fmt(fund.profit ?? 0, 'RSD')}
                         </td>
                         <td className="px-4 py-3 text-slate-700 dark:text-slate-300 tabular-nums">{fmt(fund.minimumContribution, 'RSD')}</td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? `${(fund.stats.annualReturn * 100).toFixed(2)}%` : 'N/A'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? `${(fund.stats.volatility * 100).toFixed(2)}%` : 'N/A'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? `${(fund.stats.maxDrawdown * 100).toFixed(2)}%` : 'N/A'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300" title={fund.stats?.hasSufficientData ? undefined : 'Insufficient historical data'}>
+                          {fund.stats?.hasSufficientData ? fund.stats.rewardToVariability.toFixed(3) : 'N/A'}
+                        </td>
                         {(isAgent || isSupervisor) && (
                           <td className="px-4 py-3">
                             <div className="flex items-center gap-2">

--- a/src/pages/orders/MyOrdersPage.jsx
+++ b/src/pages/orders/MyOrdersPage.jsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { usePermission } from '../../hooks/usePermission'
+import { orderService } from '../../services/orderService'
+import { fmt } from '../../utils/formatting'
+
+const STATUS_FILTERS = ['ALL', 'PENDING', 'APPROVED', 'DECLINED', 'DONE']
+const ASSET_TYPE_OPTIONS = ['', 'STOCK', 'FOREX', 'FUTURES', 'OPTION']
+const DIRECTION_OPTIONS  = ['', 'BUY', 'SELL']
+
+const STATUS_BADGE = {
+  PENDING:  'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  APPROVED: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  DECLINED: 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+  DONE:     'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300',
+  CANCELLED:'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400',
+}
+
+export default function MyOrdersPage() {
+  useWindowTitle('My Orders | AnkaBanka')
+  const { canAny } = usePermission()
+  if (!canAny(['isAgent', 'isSupervisor'])) return <Navigate to="/" replace />
+
+  const [orders, setOrders]           = useState([])
+  const [loading, setLoading]         = useState(true)
+  const [statusFilter, setStatusFilter]   = useState('ALL')
+  const [assetType, setAssetType]     = useState('')
+  const [direction, setDirection]     = useState('')
+  const [fromDate, setFromDate]       = useState('')
+  const [toDate, setToDate]           = useState('')
+  const [page, setPage]               = useState(1)
+  const [totalPages, setTotalPages]   = useState(1)
+  const PAGE_SIZE = 20
+
+  function load(p = page) {
+    setLoading(true)
+    orderService.getMyOrders({
+      status:    statusFilter === 'ALL' ? '' : statusFilter,
+      assetType,
+      direction,
+      fromDate,
+      toDate,
+      page:     p,
+      pageSize: PAGE_SIZE,
+    })
+      .then((res) => {
+        const items = Array.isArray(res) ? res : (res.orders ?? res.items ?? [])
+        setOrders(items)
+        setTotalPages(res.total_pages ?? 1)
+      })
+      .catch(() => setOrders([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    setPage(1)
+    load(1)
+  }, [statusFilter, assetType, direction, fromDate, toDate])
+
+  function handlePage(next) {
+    setPage(next)
+    load(next)
+  }
+
+  function effectiveStatus(o) {
+    if (o.is_done ?? o.isDone) return 'DONE'
+    return o.status ?? '—'
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <p className="text-xs tracking-widest uppercase text-violet-600 dark:text-violet-400 mb-4">Portal</p>
+        <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white mb-1">My Orders</h1>
+        <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-10" />
+
+        {/* Status pills */}
+        <div className="flex gap-2 mb-4 flex-wrap">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f}
+              onClick={() => setStatusFilter(f)}
+              className={`px-4 py-1.5 text-xs tracking-widest uppercase rounded-full transition-colors ${
+                statusFilter === f
+                  ? 'bg-violet-600 text-white'
+                  : 'bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:border-violet-400'
+              }`}
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+
+        {/* Extra filters */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 mb-6 shadow-sm">
+          <p className="text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 mb-4">Filters</p>
+          <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Asset Type</label>
+              <select value={assetType} onChange={(e) => setAssetType(e.target.value)} className="input-field w-full">
+                {ASSET_TYPE_OPTIONS.map((t) => <option key={t} value={t}>{t || 'All'}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Direction</label>
+              <select value={direction} onChange={(e) => setDirection(e.target.value)} className="input-field w-full">
+                {DIRECTION_OPTIONS.map((d) => <option key={d} value={d}>{d || 'All'}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">From</label>
+              <input type="date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} className="input-field w-full" />
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">To</label>
+              <input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)} className="input-field w-full" />
+            </div>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Loading…</div>
+          ) : orders.length === 0 ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">No orders found.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Tip', 'Hartija', 'Smer', 'Količina', 'Cijena', 'Status', 'Datum', 'Komisija'].map((h) => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widest uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {orders.map((o, i) => {
+                    const sl = effectiveStatus(o)
+                    const ticker = o.ticker ?? o.asset_ticker ?? o.asset_id ?? '—'
+                    const atype  = o.asset_type ?? '—'
+                    return (
+                      <tr key={o.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                        <td className="px-4 py-3">
+                          <span className="bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 text-xs px-2 py-0.5 rounded font-mono">
+                            {o.order_type ?? o.orderType ?? '—'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className="font-mono font-medium text-slate-900 dark:text-white">{ticker}</span>
+                          {' '}
+                          <span className="bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 text-xs px-1.5 py-0.5 rounded">{atype}</span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${
+                            o.direction === 'BUY'
+                              ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                              : 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400'
+                          }`}>
+                            {o.direction}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{o.quantity}</td>
+                        <td className="px-4 py-3 tabular-nums font-mono text-slate-700 dark:text-slate-300">
+                          {o.price_per_unit != null ? fmt(o.price_per_unit) : '—'}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium tracking-wide rounded-full ${STATUS_BADGE[sl] ?? STATUS_BADGE.DONE}`}>
+                            {sl}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                          {o.last_modification ? new Date(o.last_modification).toLocaleDateString() : '—'}
+                        </td>
+                        <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">
+                          {o.commission_paid != null ? fmt(o.commission_paid) : '—'}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="px-4 py-3 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+              <span>Page {page} of {totalPages}</span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handlePage(page - 1)}
+                  disabled={page <= 1}
+                  className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-40 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+                >
+                  Prev
+                </button>
+                <button
+                  onClick={() => handlePage(page + 1)}
+                  disabled={page >= totalPages}
+                  className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-40 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/orders/PortfolioPage.jsx
+++ b/src/pages/orders/PortfolioPage.jsx
@@ -4,6 +4,7 @@ import useWindowTitle from '../../hooks/useWindowTitle'
 import { useAuth } from '../../context/AuthContext'
 import { portfolioService } from '../../services/portfolioService'
 import { fundService } from '../../services/fundService'
+import { dividendService } from '../../services/dividendService'
 import { fmt } from '../../utils/formatting'
 import { InvestModal, BankDepositModal, WithdrawModal } from '../../components/funds/FundModals'
 
@@ -35,6 +36,7 @@ export default function PortfolioPage() {
     { label: 'All Securities',    key: 'all' },
     { label: 'Public Securities', key: 'public' },
     ...(isAgent || isSupervisor ? [{ label: 'My Funds', key: 'funds' }] : []),
+    ...(isAgent || isSupervisor ? [{ label: 'Dividends', key: 'dividends' }] : []),
   ]
 
   const [holdings, setHoldings]   = useState([])
@@ -63,6 +65,10 @@ export default function PortfolioPage() {
   const [myFundsLoading, setMyFundsLoading] = useState(false)
   const [myFundsError, setMyFundsError] = useState(null)
   const [fundModal, setFundModal]       = useState(null) // { type, fund }
+
+  const [dividends, setDividends]           = useState([])
+  const [dividendsLoading, setDivLoading]   = useState(false)
+  const [dividendsError, setDivError]       = useState(null)
 
   useEffect(() => {
     setLoading(true)
@@ -102,6 +108,23 @@ export default function PortfolioPage() {
   useEffect(() => {
     if (activeTab.key === 'funds') loadMyFunds()
   }, [activeTab.key, loadMyFunds])
+
+  const loadDividends = useCallback(async () => {
+    setDivLoading(true)
+    setDivError(null)
+    try {
+      const res = await dividendService.getMyDividends()
+      setDividends(Array.isArray(res) ? res : (res.dividends ?? res.payouts ?? []))
+    } catch {
+      setDivError(true)
+    } finally {
+      setDivLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (activeTab.key === 'dividends') loadDividends()
+  }, [activeTab.key, loadDividends])
 
   const displayed = activeTab.key === 'public'
     ? holdings.filter(h => h.is_public)
@@ -268,8 +291,46 @@ export default function PortfolioPage() {
         </div>
       )}
 
+      {/* ── Dividende tab ── */}
+      {activeTab.key === 'dividends' && (
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {dividendsLoading ? (
+            <div className="flex items-center justify-center py-20"><p className="text-slate-500 text-sm">Loading dividends…</p></div>
+          ) : dividendsError ? (
+            <div className="flex items-center justify-center py-20"><p className="text-red-500 text-sm">Failed to load dividends.</p></div>
+          ) : dividends.length === 0 ? (
+            <div className="flex items-center justify-center py-20"><p className="text-slate-400 text-sm">No dividend payouts yet.</p></div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Ticker', 'Date', 'Quantity', 'Gross Amount', 'Tax (RSD)', 'Net Amount', 'Currency'].map(h => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {dividends.map((d, i) => (
+                    <tr key={d.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                      <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{d.ticker ?? d.stock_listing_id ?? '—'}</td>
+                      <td className="px-4 py-3 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">{d.payment_date ?? '—'}</td>
+                      <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{d.quantity != null ? Number(d.quantity).toFixed(4) : '—'}</td>
+                      <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{d.gross_amount != null ? fmt(d.gross_amount) : '—'}</td>
+                      <td className="px-4 py-3 tabular-nums text-amber-600 dark:text-amber-400">{d.tax_rsd != null ? fmt(d.tax_rsd) : '—'}</td>
+                      <td className="px-4 py-3 tabular-nums font-medium text-emerald-600 dark:text-emerald-400">{d.net_amount != null ? fmt(d.net_amount) : '—'}</td>
+                      <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{d.currency ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* ── Securities tabs ── */}
-      {activeTab.key !== 'funds' && (
+      {activeTab.key !== 'funds' && activeTab.key !== 'dividends' && (
         <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
           {loading ? (
             <div className="flex items-center justify-center py-20">

--- a/src/pages/orders/RecurringOrdersPage.jsx
+++ b/src/pages/orders/RecurringOrdersPage.jsx
@@ -1,0 +1,346 @@
+import { useEffect, useRef, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { usePermission } from '../../hooks/usePermission'
+import { useApiError } from '../../context/ApiErrorContext'
+import { recurringOrderService } from '../../services/recurringOrderService'
+import { securitiesService } from '../../services/securitiesService'
+import { apiClient } from '../../services/apiClient'
+import { fmt } from '../../utils/formatting'
+
+const CADENCE_LABELS = { DAILY: 'Daily', WEEKLY: 'Weekly', MONTHLY: 'Monthly' }
+const MODE_LABELS    = { BY_QUANTITY: 'By Quantity', BY_AMOUNT: 'By Amount' }
+
+export default function RecurringOrdersPage() {
+  useWindowTitle('Recurring Orders | AnkaBanka')
+  const { canAny } = usePermission()
+  if (!canAny(['isAgent', 'isSupervisor'])) return <Navigate to="/" replace />
+
+  const { addSuccess } = useApiError()
+  const [orders, setOrders]   = useState([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy]       = useState({})
+
+  // New recurring order modal
+  const [showNew, setShowNew]           = useState(false)
+  const [newSearch, setNewSearch]       = useState('')
+  const [newResults, setNewResults]     = useState([])
+  const [newSearchLoading, setNewSearchLoading] = useState(false)
+  const [newListing, setNewListing]     = useState(null)
+  const [newDirection, setNewDirection] = useState('BUY')
+  const [newMode, setNewMode]           = useState('BY_AMOUNT')
+  const [newValue, setNewValue]         = useState('')
+  const [newCadence, setNewCadence]     = useState('MONTHLY')
+  const [newAccountId, setNewAccountId] = useState('')
+  const [accounts, setAccounts]         = useState([])
+  const [newCreating, setNewCreating]   = useState(false)
+  const searchTimeout                   = useRef(null)
+
+  function load() {
+    setLoading(true)
+    recurringOrderService.list()
+      .then((res) => setOrders(Array.isArray(res) ? res : (res.recurring_orders ?? res.orders ?? [])))
+      .catch(() => setOrders([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function openNew() {
+    setShowNew(true)
+    setNewSearch('')
+    setNewResults([])
+    setNewListing(null)
+    setNewDirection('BUY')
+    setNewMode('BY_AMOUNT')
+    setNewValue('')
+    setNewCadence('MONTHLY')
+    setNewAccountId('')
+    try {
+      const accs = await apiClient.get('/api/bank-accounts').then((r) => r.data)
+      const list = Array.isArray(accs) ? accs : []
+      setAccounts(list)
+      if (list.length > 0) setNewAccountId(String(list[0].id ?? list[0].accountId ?? ''))
+    } catch { setAccounts([]) }
+  }
+
+  function handleSearchChange(val) {
+    setNewSearch(val)
+    setNewListing(null)
+    clearTimeout(searchTimeout.current)
+    if (!val.trim()) { setNewResults([]); return }
+    setNewSearchLoading(true)
+    searchTimeout.current = setTimeout(async () => {
+      try {
+        const res = await securitiesService.getListings({ ticker: val.trim(), pageSize: 8 })
+        setNewResults(res.items ?? [])
+      } catch { setNewResults([]) }
+      finally { setNewSearchLoading(false) }
+    }, 350)
+  }
+
+  async function handleCreate() {
+    if (!newListing || !newValue || !newAccountId) return
+    setNewCreating(true)
+    try {
+      await recurringOrderService.create({
+        assetId:   newListing.id,
+        direction: newDirection,
+        mode:      newMode,
+        value:     Number(newValue),
+        accountId: Number(newAccountId),
+        cadence:   newCadence,
+      })
+      addSuccess('Recurring order created.')
+      setShowNew(false)
+      load()
+    } catch { /* error toast */ }
+    finally { setNewCreating(false) }
+  }
+
+  async function handlePause(id) {
+    setBusy((p) => ({ ...p, [id]: true }))
+    try {
+      await recurringOrderService.pause(id)
+      setOrders((p) => p.map((o) => o.id === id ? { ...o, active: false } : o))
+      addSuccess('Recurring order paused.')
+    } finally { setBusy((p) => ({ ...p, [id]: false })) }
+  }
+
+  async function handleResume(id) {
+    setBusy((p) => ({ ...p, [id]: true }))
+    try {
+      await recurringOrderService.resume(id)
+      setOrders((p) => p.map((o) => o.id === id ? { ...o, active: true } : o))
+      addSuccess('Recurring order resumed.')
+    } finally { setBusy((p) => ({ ...p, [id]: false })) }
+  }
+
+  async function handleCancel(id) {
+    if (!window.confirm('Cancel this recurring order?')) return
+    setBusy((p) => ({ ...p, [id]: true }))
+    try {
+      await recurringOrderService.cancel(id)
+      setOrders((p) => p.filter((o) => o.id !== id))
+      addSuccess('Recurring order cancelled.')
+    } finally { setBusy((p) => ({ ...p, [id]: false })) }
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-10">
+          <div>
+            <p className="text-xs tracking-widests uppercase text-violet-600 dark:text-violet-400 mb-1">Portal</p>
+            <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white">Recurring Orders</h1>
+            <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mt-2" />
+          </div>
+          <button onClick={openNew} className="btn-primary text-xs px-5 py-2.5">
+            + New Recurring Order
+          </button>
+        </div>
+
+        {/* New recurring order modal */}
+        {showNew && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowNew(false)}>
+            <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+              <div className="px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+                <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">New Recurring Order</h2>
+              </div>
+              <div className="px-6 py-5 flex flex-col gap-4">
+                {/* Listing search */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Security</label>
+                  {newListing ? (
+                    <div className="flex items-center justify-between px-3 py-2 bg-violet-50 dark:bg-violet-900/20 rounded-lg">
+                      <span className="font-mono font-medium text-sm text-violet-700 dark:text-violet-400">{newListing.ticker}</span>
+                      <button onClick={() => { setNewListing(null); setNewSearch('') }} className="text-xs text-slate-400 hover:text-slate-600">✕</button>
+                    </div>
+                  ) : (
+                    <>
+                      <input
+                        type="text"
+                        value={newSearch}
+                        onChange={(e) => handleSearchChange(e.target.value)}
+                        className="input-field w-full"
+                        placeholder="Search ticker…"
+                        autoFocus
+                      />
+                      <div className="mt-1 flex flex-col gap-0.5 max-h-36 overflow-y-auto">
+                        {newSearchLoading && <p className="text-xs text-slate-400 py-1 text-center">Searching…</p>}
+                        {!newSearchLoading && newResults.length === 0 && newSearch.trim() && (
+                          <p className="text-xs text-slate-400 py-1 text-center">No results.</p>
+                        )}
+                        {newResults.map((l) => (
+                          <button key={l.id} onClick={() => setNewListing(l)} className="flex items-center justify-between px-2 py-1.5 rounded hover:bg-violet-50 dark:hover:bg-violet-900/20 text-left">
+                            <span className="font-mono text-sm text-violet-700 dark:text-violet-400 font-medium">{l.ticker}</span>
+                            <span className="text-xs text-slate-500 ml-2 truncate">{l.name}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                {/* Direction */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Direction</label>
+                  <select value={newDirection} onChange={(e) => setNewDirection(e.target.value)} className="input-field w-full">
+                    <option value="BUY">Buy</option>
+                    <option value="SELL">Sell</option>
+                  </select>
+                </div>
+
+                {/* Mode */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Mode</label>
+                  <select value={newMode} onChange={(e) => setNewMode(e.target.value)} className="input-field w-full">
+                    <option value="BY_AMOUNT">By Amount (currency)</option>
+                    <option value="BY_QUANTITY">By Quantity (shares)</option>
+                  </select>
+                </div>
+
+                {/* Value */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">
+                    {newMode === 'BY_AMOUNT' ? 'Amount' : 'Quantity'}
+                  </label>
+                  <input
+                    type="number"
+                    value={newValue}
+                    onChange={(e) => setNewValue(e.target.value)}
+                    className="input-field w-full"
+                    placeholder={newMode === 'BY_AMOUNT' ? 'e.g. 500' : 'e.g. 5'}
+                    min="1"
+                    step={newMode === 'BY_AMOUNT' ? '0.01' : '1'}
+                  />
+                </div>
+
+                {/* Cadence */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Frequency</label>
+                  <select value={newCadence} onChange={(e) => setNewCadence(e.target.value)} className="input-field w-full">
+                    <option value="DAILY">Daily</option>
+                    <option value="WEEKLY">Weekly</option>
+                    <option value="MONTHLY">Monthly</option>
+                  </select>
+                </div>
+
+                {/* Account */}
+                <div>
+                  <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Account</label>
+                  {accounts.length > 0 ? (
+                    <select value={newAccountId} onChange={(e) => setNewAccountId(e.target.value)} className="input-field w-full">
+                      {accounts.map((a) => (
+                        <option key={a.id ?? a.accountId} value={a.id ?? a.accountId}>
+                          {a.accountNumber ?? a.account_number ?? `Account #${a.id ?? a.accountId}`}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="number"
+                      value={newAccountId}
+                      onChange={(e) => setNewAccountId(e.target.value)}
+                      className="input-field w-full"
+                      placeholder="Account ID"
+                    />
+                  )}
+                </div>
+              </div>
+              <div className="px-6 pb-6 pt-2 border-t border-slate-100 dark:border-slate-800 flex justify-end gap-2">
+                <button onClick={() => setShowNew(false)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors rounded">Cancel</button>
+                <button
+                  onClick={handleCreate}
+                  disabled={newCreating || !newListing || !newValue || !newAccountId}
+                  className="btn-primary text-xs px-4 py-2 disabled:opacity-50"
+                >
+                  {newCreating ? 'Creating…' : 'Create'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          {loading ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">Loading…</div>
+          ) : orders.length === 0 ? (
+            <div className="px-6 py-12 text-center text-slate-400 text-sm">No recurring orders. Click <strong>+ New Recurring Order</strong> to create one.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700">
+                    {['Security', 'Direction', 'Mode / Value', 'Frequency', 'Next Run', 'Status', 'Actions'].map((h) => (
+                      <th key={h} className="px-4 py-4 text-left text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 font-medium whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {orders.map((o, i) => (
+                    <tr key={o.id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                      <td className="px-4 py-3 font-mono font-medium text-slate-900 dark:text-white">{o.ticker ?? o.asset_id ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${
+                          o.direction === 'BUY'
+                            ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                            : 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400'
+                        }`}>
+                          {o.direction}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">
+                        {MODE_LABELS[o.mode] ?? o.mode} — {fmt(o.value)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">
+                        {CADENCE_LABELS[o.cadence] ?? o.cadence}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                        {o.next_run ? new Date(o.next_run).toLocaleString() : '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center gap-1 text-xs font-medium ${o.active ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-400 dark:text-slate-500'}`}>
+                          <span className={`w-1.5 h-1.5 rounded-full ${o.active ? 'bg-emerald-500' : 'bg-slate-400'}`} />
+                          {o.active ? 'Active' : 'Paused'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex gap-2">
+                          {o.active ? (
+                            <button
+                              onClick={() => handlePause(o.id)}
+                              disabled={busy[o.id]}
+                              className="px-3 py-1 text-xs tracking-widests uppercase rounded border border-yellow-400 dark:border-yellow-600 text-yellow-700 dark:text-yellow-400 hover:bg-yellow-50 dark:hover:bg-yellow-900/20 transition-colors disabled:opacity-50"
+                            >
+                              Pause
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => handleResume(o.id)}
+                              disabled={busy[o.id]}
+                              className="px-3 py-1 text-xs tracking-widests uppercase rounded border border-emerald-400 dark:border-emerald-600 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors disabled:opacity-50"
+                            >
+                              Resume
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleCancel(o.id)}
+                            disabled={busy[o.id]}
+                            className="px-3 py-1 text-xs tracking-widests uppercase rounded border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/otc/OtcNegotiationDetailPage.jsx
+++ b/src/pages/otc/OtcNegotiationDetailPage.jsx
@@ -48,6 +48,8 @@ export default function OtcNegotiationDetailPage() {
   const [selectedAccountId, setSelectedAccountId] = useState('')
   const [accountsLoading,   setAccountsLoading]   = useState(false)
 
+  const [history, setHistory] = useState([])
+
   const negRef = useRef(null)
 
   useEffect(() => {
@@ -69,6 +71,10 @@ export default function OtcNegotiationDetailPage() {
       })
       .catch(() => setError(true))
       .finally(() => setLoading(false))
+  }, [id])
+
+  useEffect(() => {
+    otcService.getNegotiationHistory(id).then(setHistory).catch(() => {})
   }, [id])
 
   // Poll every 10 s for cross-bank negotiations so counter-offers from the partner appear automatically.
@@ -398,6 +404,68 @@ export default function OtcNegotiationDetailPage() {
           </>
         )}
       </div>
+
+      {history.length > 0 && (
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm p-6 mb-6">
+          <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 mb-4">Negotiation History</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 dark:border-slate-700">
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Action</th>
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">By</th>
+                  <th className="px-3 py-2 text-right text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Amount</th>
+                  <th className="px-3 py-2 text-right text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Price/Stock</th>
+                  <th className="px-3 py-2 text-right text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Premium</th>
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Settlement</th>
+                  <th className="px-3 py-2 text-left text-xs font-medium tracking-widest uppercase text-slate-500 dark:text-slate-400">Timestamp</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {history.map(e => {
+                  const badge = {
+                    CREATED:      'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+                    COUNTER_OFFER:'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+                    ACCEPTED:     'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+                    REJECTED:     'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+                  }[e.action] ?? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'
+                  const fmtChange = (oldVal, newVal) =>
+                    oldVal != null && newVal != null && String(oldVal) !== String(newVal)
+                      ? <span><span className="line-through text-slate-400">{oldVal}</span><span className="mx-1 text-slate-400">→</span>{newVal}</span>
+                      : (newVal ?? oldVal ?? <span className="text-slate-400">—</span>)
+                  return (
+                    <tr key={e.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
+                      <td className="px-3 py-3">
+                        <span className={`inline-block text-xs font-semibold px-2 py-0.5 rounded ${badge}`}>
+                          {e.action.replace('_', ' ')}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3 text-slate-700 dark:text-slate-300">
+                        {e.actorName || `${e.actorType} #${e.actorId}`}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldAmount, e.newAmount)}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldPricePerStock, e.newPricePerStock)}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldPremium, e.newPremium)}
+                      </td>
+                      <td className="px-3 py-3 text-slate-700 dark:text-slate-300">
+                        {fmtChange(e.oldSettlementDate, e.newSettlementDate)}
+                      </td>
+                      <td className="px-3 py-3 text-slate-500 dark:text-slate-400 text-xs">
+                        {e.timestamp ? fmtDateTime(e.timestamp) : '—'}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/securities/ListingDetailPage.jsx
+++ b/src/pages/securities/ListingDetailPage.jsx
@@ -6,6 +6,10 @@ import {
 } from 'recharts'
 import useWindowTitle from '../../hooks/useWindowTitle'
 import { securitiesService } from '../../services/securitiesService'
+import { watchlistService } from '../../services/watchlistService'
+import { priceAlertService } from '../../services/priceAlertService'
+import { recurringOrderService } from '../../services/recurringOrderService'
+import { apiClient } from '../../services/apiClient'
 import { fmt } from '../../utils/formatting'
 
 const PERIODS = [
@@ -37,6 +41,31 @@ export default function ListingDetailPage() {
   const [historyLoading, setHistoryLoading] = useState(false)
   const [error, setError]             = useState(null)
   const skipInitialPeriod             = useRef(true)
+
+  // Alert modal
+  const [showAlert, setShowAlert]       = useState(false)
+  const [alertCondition, setAlertCondition] = useState('ABOVE')
+  const [alertThreshold, setAlertThreshold] = useState('')
+  const [alertNotif, setAlertNotif]     = useState('BOTH')
+  const [alertBusy, setAlertBusy]       = useState(false)
+  const [alertDone, setAlertDone]       = useState(false)
+
+  // Watchlist modal
+  const [showWatchlist, setShowWatchlist]   = useState(false)
+  const [watchlists, setWatchlists]         = useState([])
+  const [watchlistLoading, setWatchlistLoading] = useState(false)
+  const [watchlistBusy, setWatchlistBusy]   = useState(false)
+
+  // Recurring order modal
+  const [showRecurring, setShowRecurring]   = useState(false)
+  const [recDirection, setRecDirection]     = useState('BUY')
+  const [recMode, setRecMode]               = useState('BY_AMOUNT')
+  const [recValue, setRecValue]             = useState('')
+  const [recCadence, setRecCadence]         = useState('MONTHLY')
+  const [recAccountId, setRecAccountId]     = useState('')
+  const [recAccounts, setRecAccounts]       = useState([])
+  const [recBusy, setRecBusy]               = useState(false)
+  const [recDone, setRecDone]               = useState(false)
 
   useWindowTitle(listing ? `${listing.ticker} | AnkaBanka` : 'Securities | AnkaBanka')
 
@@ -91,6 +120,74 @@ export default function ListingDetailPage() {
     )
   }
 
+  async function handleCreateAlert() {
+    if (!alertThreshold) return
+    setAlertBusy(true)
+    try {
+      await priceAlertService.create({
+        listingId: listing.id,
+        condition: alertCondition,
+        threshold: Number(alertThreshold),
+        notificationType: alertNotif,
+      })
+      setAlertDone(true)
+      setTimeout(() => { setShowAlert(false); setAlertDone(false); setAlertThreshold('') }, 1200)
+    } catch { /* error toast */ }
+    finally { setAlertBusy(false) }
+  }
+
+  async function openWatchlistModal() {
+    setShowWatchlist(true)
+    setWatchlistLoading(true)
+    try {
+      const res = await watchlistService.listWatchlists()
+      setWatchlists(Array.isArray(res) ? res : (res.watchlists ?? []))
+    } catch { setWatchlists([]) }
+    finally { setWatchlistLoading(false) }
+  }
+
+  async function handleAddToWatchlist(wlId) {
+    setWatchlistBusy(true)
+    try {
+      await watchlistService.addItem(wlId, listing.id)
+      setShowWatchlist(false)
+    } catch { /* error toast */ }
+    finally { setWatchlistBusy(false) }
+  }
+
+  async function openRecurringModal() {
+    setShowRecurring(true)
+    setRecDone(false)
+    setRecDirection('BUY')
+    setRecMode('BY_AMOUNT')
+    setRecValue('')
+    setRecCadence('MONTHLY')
+    try {
+      const accs = await apiClient.get('/api/bank-accounts').then((r) => r.data)
+      const list = Array.isArray(accs) ? accs : []
+      setRecAccounts(list)
+      if (list.length > 0) setRecAccountId(String(list[0].id ?? list[0].accountId ?? ''))
+    } catch { setRecAccounts([]) }
+  }
+
+  async function handleCreateRecurring() {
+    if (!recValue || !recAccountId) return
+    setRecBusy(true)
+    try {
+      await recurringOrderService.create({
+        assetId:   listing.id,
+        direction: recDirection,
+        mode:      recMode,
+        value:     Number(recValue),
+        accountId: Number(recAccountId),
+        cadence:   recCadence,
+      })
+      setRecDone(true)
+      setTimeout(() => { setShowRecurring(false); setRecDone(false); setRecValue('') }, 1200)
+    } catch { /* error toast */ }
+    finally { setRecBusy(false) }
+  }
+
   const sortedHistory = [...history].sort((a, b) => (a.date < b.date ? 1 : -1))
 
   return (
@@ -106,17 +203,149 @@ export default function ListingDetailPage() {
             </h1>
             <p className="text-slate-500 dark:text-slate-400 text-sm mt-1">{listing.name}</p>
           </div>
-          <div className="flex items-center gap-4 mt-2">
-            <button
-              onClick={() => navigate(`/orders/new?ticker=${listing.ticker}&direction=BUY`)}
-              className="btn-primary"
-            >
-              Buy
-            </button>
-            <Link to="/securities" className="text-sm text-violet-600 dark:text-violet-400 hover:underline">
-              ← Back to Securities
-            </Link>
+          <div className="flex items-center gap-2 mt-2 flex-wrap">
+            <button onClick={() => navigate(`/orders/new?ticker=${listing.ticker}&direction=BUY`)} className="btn-primary text-xs px-4 py-2">Buy</button>
+            <button onClick={() => { setShowAlert(true); setAlertDone(false) }} className="text-xs px-4 py-2 border border-orange-300 dark:border-orange-600 text-orange-700 dark:text-orange-400 hover:bg-orange-50 dark:hover:bg-orange-900/20 rounded transition-colors">Set Alert</button>
+            <button onClick={openWatchlistModal} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 rounded transition-colors">+ Watchlist</button>
+            <button onClick={openRecurringModal} className="text-xs px-4 py-2 border border-violet-300 dark:border-violet-600 text-violet-700 dark:text-violet-400 hover:bg-violet-50 dark:hover:bg-violet-900/20 rounded transition-colors">Recurring Order</button>
+            <Link to="/securities" className="text-sm text-violet-600 dark:text-violet-400 hover:underline ml-2">← Back</Link>
           </div>
+
+          {/* Alert modal */}
+          {showAlert && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowAlert(false)}>
+              <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-xs mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+                <div className="px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-800">
+                  <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">Set Alert — {listing.ticker}</h2>
+                </div>
+                {alertDone ? (
+                  <div className="px-6 py-8 text-center text-emerald-600 dark:text-emerald-400 text-sm font-medium">Alert created ✓</div>
+                ) : (
+                  <div className="px-6 py-4 flex flex-col gap-3">
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">Condition</label>
+                      <select value={alertCondition} onChange={(e) => setAlertCondition(e.target.value)} className="input-field w-full">
+                        <option value="ABOVE">Price Above</option>
+                        <option value="BELOW">Price Below</option>
+                        <option value="CHANGE_PCT_UP">Change % Up</option>
+                        <option value="CHANGE_PCT_DOWN">Change % Down</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">Threshold</label>
+                      <input type="number" value={alertThreshold} onChange={(e) => setAlertThreshold(e.target.value)} className="input-field w-full" placeholder="e.g. 150.00" min="0" step="0.01" autoFocus />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">Notification</label>
+                      <select value={alertNotif} onChange={(e) => setAlertNotif(e.target.value)} className="input-field w-full">
+                        <option value="BOTH">Email + In-app</option>
+                        <option value="EMAIL">Email only</option>
+                        <option value="IN_APP">In-app only</option>
+                      </select>
+                    </div>
+                  </div>
+                )}
+                {!alertDone && (
+                  <div className="px-6 pb-5 flex justify-end gap-2">
+                    <button onClick={() => setShowAlert(false)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 rounded">Cancel</button>
+                    <button onClick={handleCreateAlert} disabled={alertBusy || !alertThreshold} className="btn-primary text-xs px-4 py-2 disabled:opacity-50">{alertBusy ? 'Creating…' : 'Create Alert'}</button>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Watchlist modal */}
+          {showWatchlist && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowWatchlist(false)}>
+              <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-xs mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+                <div className="px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-800">
+                  <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">Add {listing.ticker} to Watchlist</h2>
+                </div>
+                <div className="px-6 py-4">
+                  {watchlistLoading ? (
+                    <p className="text-sm text-slate-400 text-center py-4">Loading…</p>
+                  ) : watchlists.length === 0 ? (
+                    <p className="text-sm text-slate-400 text-center py-4">No watchlists. Create one first.</p>
+                  ) : (
+                    <div className="flex flex-col gap-1">
+                      {watchlists.map((wl) => (
+                        <button key={wl.id} onClick={() => handleAddToWatchlist(wl.id)} disabled={watchlistBusy} className="text-left px-3 py-2.5 rounded-lg hover:bg-violet-50 dark:hover:bg-violet-900/20 text-sm text-slate-700 dark:text-slate-300 font-medium transition-colors disabled:opacity-50">
+                          {wl.name}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="px-6 pb-5 flex justify-end">
+                  <button onClick={() => setShowWatchlist(false)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 rounded">Cancel</button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Recurring order modal */}
+          {showRecurring && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowRecurring(false)}>
+              <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-xs mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+                <div className="px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-800">
+                  <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">Recurring Order — {listing.ticker}</h2>
+                </div>
+                {recDone ? (
+                  <div className="px-6 py-8 text-center text-emerald-600 dark:text-emerald-400 text-sm font-medium">Recurring order created ✓</div>
+                ) : (
+                  <div className="px-6 py-4 flex flex-col gap-3">
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">Direction</label>
+                      <select value={recDirection} onChange={(e) => setRecDirection(e.target.value)} className="input-field w-full">
+                        <option value="BUY">Buy</option>
+                        <option value="SELL">Sell</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">Mode</label>
+                      <select value={recMode} onChange={(e) => setRecMode(e.target.value)} className="input-field w-full">
+                        <option value="BY_AMOUNT">By Amount (currency)</option>
+                        <option value="BY_QUANTITY">By Quantity (shares)</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">{recMode === 'BY_AMOUNT' ? 'Amount' : 'Quantity'}</label>
+                      <input type="number" value={recValue} onChange={(e) => setRecValue(e.target.value)} className="input-field w-full" placeholder={recMode === 'BY_AMOUNT' ? 'e.g. 500' : 'e.g. 5'} min="1" step={recMode === 'BY_AMOUNT' ? '0.01' : '1'} autoFocus />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">Frequency</label>
+                      <select value={recCadence} onChange={(e) => setRecCadence(e.target.value)} className="input-field w-full">
+                        <option value="DAILY">Daily</option>
+                        <option value="WEEKLY">Weekly</option>
+                        <option value="MONTHLY">Monthly</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-slate-500 mb-1">Account</label>
+                      {recAccounts.length > 0 ? (
+                        <select value={recAccountId} onChange={(e) => setRecAccountId(e.target.value)} className="input-field w-full">
+                          {recAccounts.map((a) => (
+                            <option key={a.id ?? a.accountId} value={a.id ?? a.accountId}>
+                              {a.accountNumber ?? a.account_number ?? `Account #${a.id ?? a.accountId}`}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input type="number" value={recAccountId} onChange={(e) => setRecAccountId(e.target.value)} className="input-field w-full" placeholder="Account ID" />
+                      )}
+                    </div>
+                  </div>
+                )}
+                {!recDone && (
+                  <div className="px-6 pb-5 flex justify-end gap-2">
+                    <button onClick={() => setShowRecurring(false)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 rounded">Cancel</button>
+                    <button onClick={handleCreateRecurring} disabled={recBusy || !recValue || !recAccountId} className="btn-primary text-xs px-4 py-2 disabled:opacity-50">{recBusy ? 'Creating…' : 'Create'}</button>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
         </div>
         <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mb-8" />
 

--- a/src/pages/watchlists/WatchlistPage.jsx
+++ b/src/pages/watchlists/WatchlistPage.jsx
@@ -1,0 +1,300 @@
+import { useEffect, useState, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useWindowTitle from '../../hooks/useWindowTitle'
+import { useApiError } from '../../context/ApiErrorContext'
+import { watchlistService } from '../../services/watchlistService'
+import { securitiesService } from '../../services/securitiesService'
+import { fmt } from '../../utils/formatting'
+
+export default function WatchlistPage() {
+  useWindowTitle('Watchlists | AnkaBanka')
+  const navigate = useNavigate()
+  const { addSuccess, addToast } = useApiError()
+
+  const [watchlists, setWatchlists]   = useState([])
+  const [loading, setLoading]         = useState(true)
+  const [expanded, setExpanded]       = useState({})
+  const [items, setItems]             = useState({})
+  const [loadingItems, setLoadingItems] = useState({})
+  const [showCreate, setShowCreate]   = useState(false)
+  const [newName, setNewName]         = useState('')
+  const [creating, setCreating]       = useState(false)
+
+  // Add security modal
+  const [addModal, setAddModal]           = useState(null) // watchlist id or null
+  const [addSearch, setAddSearch]         = useState('')
+  const [addResults, setAddResults]       = useState([])
+  const [addSearchLoading, setAddSearchLoading] = useState(false)
+  const [addBusy, setAddBusy]             = useState(false)
+  const searchTimeout                     = useRef(null)
+
+  function load() {
+    setLoading(true)
+    watchlistService.listWatchlists()
+      .then((res) => setWatchlists(Array.isArray(res) ? res : (res.watchlists ?? [])))
+      .catch(() => setWatchlists([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function toggleExpand(wl) {
+    const id = wl.id
+    if (expanded[id]) {
+      setExpanded((p) => ({ ...p, [id]: false }))
+      return
+    }
+    setExpanded((p) => ({ ...p, [id]: true }))
+    if (items[id]) return
+    setLoadingItems((p) => ({ ...p, [id]: true }))
+    try {
+      const res = await watchlistService.getItems(id)
+      setItems((p) => ({ ...p, [id]: Array.isArray(res) ? res : (res.items ?? []) }))
+    } catch {
+      setItems((p) => ({ ...p, [id]: [] }))
+    } finally {
+      setLoadingItems((p) => ({ ...p, [id]: false }))
+    }
+  }
+
+  async function handleDelete(id) {
+    if (!window.confirm('Delete this watchlist?')) return
+    try {
+      await watchlistService.deleteWatchlist(id)
+      setWatchlists((p) => p.filter((w) => w.id !== id))
+      addSuccess('Watchlist deleted.')
+    } catch { /* error toast from interceptor */ }
+  }
+
+  async function handleRemoveItem(watchlistId, listingId) {
+    try {
+      await watchlistService.removeItem(watchlistId, listingId)
+      setItems((p) => ({ ...p, [watchlistId]: (p[watchlistId] ?? []).filter((i) => i.listing_id !== listingId) }))
+      addSuccess('Removed from watchlist.')
+    } catch { /* error toast */ }
+  }
+
+  function openAddModal(wlId) {
+    setAddModal(wlId)
+    setAddSearch('')
+    setAddResults([])
+  }
+
+  function handleAddSearch(val) {
+    setAddSearch(val)
+    clearTimeout(searchTimeout.current)
+    if (!val.trim()) { setAddResults([]); return }
+    setAddSearchLoading(true)
+    searchTimeout.current = setTimeout(async () => {
+      try {
+        const res = await securitiesService.getListings({ ticker: val.trim(), pageSize: 8 })
+        setAddResults(res.items ?? [])
+      } catch { setAddResults([]) }
+      finally { setAddSearchLoading(false) }
+    }, 350)
+  }
+
+  async function handleAddItem(listing) {
+    setAddBusy(true)
+    try {
+      await watchlistService.addItem(addModal, listing.id)
+      // refresh items for this watchlist
+      const res = await watchlistService.getItems(addModal)
+      setItems((p) => ({ ...p, [addModal]: Array.isArray(res) ? res : (res.items ?? []) }))
+      addSuccess(`${listing.ticker} added to watchlist.`)
+      setAddModal(null)
+    } catch { /* error toast */ }
+    finally { setAddBusy(false) }
+  }
+
+  async function handleCreate() {
+    if (!newName.trim()) return
+    setCreating(true)
+    try {
+      await watchlistService.createWatchlist(newName.trim())
+      setNewName('')
+      setShowCreate(false)
+      load()
+      addSuccess('Watchlist created.')
+    } catch {
+      /* error toast from interceptor */
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 px-6 py-16">
+      <div className="max-w-5xl mx-auto">
+        <div className="flex items-center justify-between mb-10">
+          <div>
+            <p className="text-xs tracking-widests uppercase text-violet-600 dark:text-violet-400 mb-1">Portal</p>
+            <h1 className="font-serif text-4xl font-light text-slate-900 dark:text-white">Watchlists</h1>
+            <div className="w-10 h-px bg-violet-500 dark:bg-violet-400 mt-2" />
+          </div>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="btn-primary text-xs px-5 py-2.5"
+          >
+            + New Watchlist
+          </button>
+        </div>
+
+        {/* Add security modal */}
+        {addModal && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setAddModal(null)}>
+            <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+              <div className="px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+                <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">Add Security</h2>
+              </div>
+              <div className="px-6 py-5">
+                <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Search by ticker</label>
+                <input
+                  type="text"
+                  value={addSearch}
+                  onChange={(e) => handleAddSearch(e.target.value)}
+                  className="input-field w-full"
+                  placeholder="e.g. AAPL"
+                  autoFocus
+                />
+                <div className="mt-3 flex flex-col gap-1 max-h-52 overflow-y-auto">
+                  {addSearchLoading && <p className="text-xs text-slate-400 py-2 text-center">Searching…</p>}
+                  {!addSearchLoading && addResults.length === 0 && addSearch.trim() && (
+                    <p className="text-xs text-slate-400 py-2 text-center">No results.</p>
+                  )}
+                  {addResults.map((l) => (
+                    <button
+                      key={l.id}
+                      onClick={() => handleAddItem(l)}
+                      disabled={addBusy}
+                      className="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-violet-50 dark:hover:bg-violet-900/20 text-left transition-colors disabled:opacity-50"
+                    >
+                      <span className="font-mono font-medium text-sm text-violet-700 dark:text-violet-400">{l.ticker}</span>
+                      <span className="text-xs text-slate-500 dark:text-slate-400 truncate ml-3">{l.name}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="px-6 pb-5 flex justify-end">
+                <button onClick={() => setAddModal(null)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors rounded">Cancel</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Create modal */}
+        {showCreate && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowCreate(false)}>
+            <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+              <div className="px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+                <h2 className="font-serif text-lg font-light text-slate-900 dark:text-white">New Watchlist</h2>
+              </div>
+              <div className="px-6 py-5">
+                <label className="block text-xs text-slate-500 dark:text-slate-400 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+                  className="input-field w-full"
+                  placeholder="npr. Tech stocks"
+                  autoFocus
+                />
+              </div>
+              <div className="px-6 pb-6 pt-2 border-t border-slate-100 dark:border-slate-800 flex justify-end gap-2">
+                <button onClick={() => setShowCreate(false)} className="text-xs px-4 py-2 border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors">Cancel</button>
+                <button onClick={handleCreate} disabled={creating || !newName.trim()} className="btn-primary text-xs px-4 py-2 disabled:opacity-50">
+                  {creating ? 'Creating…' : 'Create'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Watchlist list */}
+        {loading ? (
+          <div className="text-center text-slate-400 text-sm py-12">Loading…</div>
+        ) : watchlists.length === 0 ? (
+          <div className="text-center text-slate-400 text-sm py-12">No watchlists. Create your first one.</div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {watchlists.map((wl) => (
+              <div key={wl.id} className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+                <div className="flex items-center justify-between px-5 py-4">
+                  <button
+                    onClick={() => toggleExpand(wl)}
+                    className="flex items-center gap-3 text-left flex-1"
+                  >
+                    <svg className={`w-4 h-4 text-slate-400 transition-transform ${expanded[wl.id] ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5l7 7-7 7" />
+                    </svg>
+                    <span className="font-medium text-slate-900 dark:text-white">{wl.name}</span>
+                    <span className="text-xs text-slate-400 dark:text-slate-500">{wl.item_count != null ? `${wl.item_count} items` : ''}</span>
+                  </button>
+                  <button
+                    onClick={() => handleDelete(wl.id)}
+                    className="text-xs text-red-500 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                  >
+                    Delete
+                  </button>
+                </div>
+
+                {expanded[wl.id] && (
+                  <div className="border-t border-slate-100 dark:border-slate-800">
+                    {loadingItems[wl.id] ? (
+                      <div className="px-5 py-4 text-sm text-slate-400">Loading items…</div>
+                    ) : (items[wl.id] ?? []).length === 0 ? (
+                      <div className="px-5 py-4 flex items-center justify-between">
+                        <span className="text-sm text-slate-400">No items.</span>
+                        <button onClick={() => openAddModal(wl.id)} className="text-xs text-violet-600 dark:text-violet-400 hover:underline">+ Add Security</button>
+                      </div>
+                    ) : (
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b border-slate-100 dark:border-slate-800">
+                            {['Ticker', 'Name', 'Type', 'Price', 'Change', 'Volume', ''].map((h) => (
+                              <th key={h} className="px-4 py-3 text-left text-xs tracking-widests uppercase text-slate-500 dark:text-slate-400 font-medium">{h}</th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {(items[wl.id] ?? []).map((item, i) => {
+                            const changePct = item.change_percent ?? (item.change && item.price ? (item.change / item.price * 100) : null)
+                            return (
+                              <tr key={item.id ?? item.listing_id} className={`border-b border-slate-100 dark:border-slate-800 last:border-0 ${i % 2 === 0 ? '' : 'bg-slate-50/50 dark:bg-slate-800/20'}`}>
+                                <td className="px-4 py-3 font-mono font-medium text-violet-600 dark:text-violet-400 cursor-pointer hover:underline" onClick={() => navigate(`/securities/${item.listing_id}`)}>
+                                  {item.ticker ?? '—'}
+                                </td>
+                                <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{item.name ?? '—'}</td>
+                                <td className="px-4 py-3">
+                                  <span className="bg-slate-100 dark:bg-slate-800 text-slate-500 text-xs px-1.5 py-0.5 rounded font-mono">{item.type ?? '—'}</span>
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-slate-700 dark:text-slate-300">{item.price != null ? fmt(item.price) : '—'}</td>
+                                <td className={`px-4 py-3 tabular-nums font-medium ${changePct == null ? '' : changePct >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500 dark:text-red-400'}`}>
+                                  {changePct != null ? `${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%` : '—'}
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-slate-600 dark:text-slate-400">{item.volume ?? '—'}</td>
+                                <td className="px-4 py-3">
+                                  <button onClick={() => handleRemoveItem(wl.id, item.listing_id)} className="text-xs text-red-500 hover:text-red-600 transition-colors">Remove</button>
+                                </td>
+                              </tr>
+                            )
+                          })}
+                        </tbody>
+                      </table>
+                    )}
+                    {!loadingItems[wl.id] && (items[wl.id] ?? []).length > 0 && (
+                      <div className="px-5 py-3 border-t border-slate-100 dark:border-slate-800 flex justify-end">
+                        <button onClick={() => openAddModal(wl.id)} className="text-xs text-violet-600 dark:text-violet-400 hover:underline">+ Add Security</button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/services/auditService.js
+++ b/src/services/auditService.js
@@ -1,0 +1,13 @@
+import { apiClient } from './apiClient'
+
+export const auditService = {
+  async getAuditLogs({ action, actorId, fromDate, toDate, page = 1, pageSize = 20 } = {}) {
+    const params = { page, page_size: pageSize }
+    if (action)  params.action   = action
+    if (actorId) params.actor_id = actorId
+    if (fromDate) params.from_date = fromDate
+    if (toDate)   params.to_date   = toDate
+    const { data } = await apiClient.get('/audit-logs', { params })
+    return data
+  },
+}

--- a/src/services/clientOtcService.js
+++ b/src/services/clientOtcService.js
@@ -50,4 +50,9 @@ export const clientOtcService = {
     const { data } = await clientApiClient.post(`/otc/contracts/${id}/exercise`, { buyerAccountId })
     return data
   },
+
+  async getNegotiationHistory(id) {
+    const { data } = await clientApiClient.get(`/otc/negotiations/${id}/history`)
+    return data
+  },
 }

--- a/src/services/clientPortfolioService.js
+++ b/src/services/clientPortfolioService.js
@@ -50,4 +50,9 @@ export const clientPortfolioService = {
     const { data } = await clientApiClient.get(`/investment/funds/${id}/performance`, { params: { from, to } })
     return Array.isArray(data) ? data : []
   },
+
+  async getAveragePerformance(from, to) {
+    const { data } = await clientApiClient.get('/investment/funds/average-performance', { params: { from, to } })
+    return Array.isArray(data) ? data : []
+  },
 }

--- a/src/services/dividendService.js
+++ b/src/services/dividendService.js
@@ -1,0 +1,24 @@
+import { apiClient } from './apiClient'
+import { clientApiClient } from './clientApiClient'
+
+export const dividendService = {
+  async getMyDividends({ listingId, fromDate, toDate, page = 1, pageSize = 20 } = {}) {
+    const url = listingId ? `/dividends/my/${listingId}` : '/dividends/my'
+    const params = { page, page_size: pageSize }
+    if (fromDate) params.from_date = fromDate
+    if (toDate)   params.to_date   = toDate
+    const { data } = await apiClient.get(url, { params })
+    return data
+  },
+}
+
+export const clientDividendService = {
+  async getMyDividends({ listingId, fromDate, toDate, page = 1, pageSize = 20 } = {}) {
+    const url = listingId ? `/dividends/my/${listingId}` : '/dividends/my'
+    const params = { page, page_size: pageSize }
+    if (fromDate) params.from_date = fromDate
+    if (toDate)   params.to_date   = toDate
+    const { data } = await clientApiClient.get(url, { params })
+    return data
+  },
+}

--- a/src/services/fundService.js
+++ b/src/services/fundService.js
@@ -70,4 +70,9 @@ export const fundService = {
     const { data } = await apiClient.get('/investment/funds/bank-positions')
     return Array.isArray(data) ? data : (data.positions ?? data.items ?? [])
   },
+
+  async getAveragePerformance(from, to) {
+    const { data } = await apiClient.get('/investment/funds/average-performance', { params: { from, to } })
+    return data
+  },
 }

--- a/src/services/fundService.js
+++ b/src/services/fundService.js
@@ -57,8 +57,8 @@ export const fundService = {
   },
 
   async getMyPositions() {
-    const { data } = await apiClient.get('/investment/funds/my-positions')
-    return Array.isArray(data) ? data : (data.positions ?? data.items ?? [])
+    const { data } = await apiClient.get('/investment/funds')
+    return Array.isArray(data) ? data : (data.funds ?? data.items ?? [])
   },
 
   async getManagedFunds(managerId) {

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -80,4 +80,26 @@ export const orderService = {
     const { data } = await apiClient.delete(`/orders/${id}/portions`)
     return data
   },
+
+  async getMyOrders({ status, assetType, direction, fromDate, toDate, page = 1, pageSize = 20 } = {}) {
+    const params = { page, page_size: pageSize }
+    if (status)    params.status     = status
+    if (assetType) params.asset_type = assetType
+    if (direction) params.direction  = direction
+    if (fromDate)  params.from_date  = fromDate
+    if (toDate)    params.to_date    = toDate
+    const { data } = await apiClient.get('/orders/my', { params })
+    return data
+  },
+
+  async getClientOrders({ status, assetType, direction, fromDate, toDate, page = 1, pageSize = 20 } = {}) {
+    const params = { page, page_size: pageSize }
+    if (status)    params.status     = status
+    if (assetType) params.asset_type = assetType
+    if (direction) params.direction  = direction
+    if (fromDate)  params.from_date  = fromDate
+    if (toDate)    params.to_date    = toDate
+    const { data } = await clientApiClient.get('/client/orders', { params })
+    return data
+  },
 }

--- a/src/services/otcService.js
+++ b/src/services/otcService.js
@@ -50,4 +50,9 @@ export const otcService = {
     const { data } = await apiClient.post(`/otc/contracts/${id}/exercise`, { buyerAccountId })
     return data
   },
+
+  async getNegotiationHistory(id) {
+    const { data } = await apiClient.get(`/otc/negotiations/${id}/history`)
+    return data
+  },
 }

--- a/src/services/priceAlertService.js
+++ b/src/services/priceAlertService.js
@@ -1,0 +1,42 @@
+import { apiClient } from './apiClient'
+import { clientApiClient } from './clientApiClient'
+
+export const priceAlertService = {
+  async create({ listingId, condition, threshold, notificationType = 'BOTH' }) {
+    const { data } = await apiClient.post('/price-alerts', {
+      listing_id: listingId,
+      condition,
+      threshold,
+      notification_type: notificationType,
+    })
+    return data
+  },
+  async list() {
+    const { data } = await apiClient.get('/price-alerts')
+    return data
+  },
+  async delete(id) {
+    const { data } = await apiClient.delete(`/price-alerts/${id}`)
+    return data
+  },
+}
+
+export const clientPriceAlertService = {
+  async create({ listingId, condition, threshold, notificationType = 'BOTH' }) {
+    const { data } = await clientApiClient.post('/price-alerts', {
+      listing_id: listingId,
+      condition,
+      threshold,
+      notification_type: notificationType,
+    })
+    return data
+  },
+  async list() {
+    const { data } = await clientApiClient.get('/price-alerts')
+    return data
+  },
+  async delete(id) {
+    const { data } = await clientApiClient.delete(`/price-alerts/${id}`)
+    return data
+  },
+}

--- a/src/services/recurringOrderService.js
+++ b/src/services/recurringOrderService.js
@@ -1,0 +1,62 @@
+import { apiClient } from './apiClient'
+import { clientApiClient } from './clientApiClient'
+
+export const recurringOrderService = {
+  async create({ assetId, direction, mode, value, accountId, cadence }) {
+    const { data } = await apiClient.post('/recurring-orders', {
+      asset_id: assetId,
+      direction,
+      mode,
+      value,
+      account_id: accountId,
+      cadence,
+    })
+    return data
+  },
+  async list() {
+    const { data } = await apiClient.get('/recurring-orders')
+    return data
+  },
+  async pause(id) {
+    const { data } = await apiClient.put(`/recurring-orders/${id}/pause`)
+    return data
+  },
+  async resume(id) {
+    const { data } = await apiClient.put(`/recurring-orders/${id}/resume`)
+    return data
+  },
+  async cancel(id) {
+    const { data } = await apiClient.delete(`/recurring-orders/${id}`)
+    return data
+  },
+}
+
+export const clientRecurringOrderService = {
+  async create({ assetId, direction, mode, value, accountId, cadence }) {
+    const { data } = await clientApiClient.post('/recurring-orders', {
+      asset_id: assetId,
+      direction,
+      mode,
+      value,
+      account_id: accountId,
+      cadence,
+    })
+    return data
+  },
+  async list() {
+    const { data } = await clientApiClient.get('/recurring-orders')
+    return data
+  },
+  async pause(id) {
+    const { data } = await clientApiClient.put(`/recurring-orders/${id}/pause`)
+    return data
+  },
+  async resume(id) {
+    const { data } = await clientApiClient.put(`/recurring-orders/${id}/resume`)
+    return data
+  },
+  async cancel(id) {
+    const { data } = await clientApiClient.delete(`/recurring-orders/${id}`)
+    return data
+  },
+}

--- a/src/services/watchlistService.js
+++ b/src/services/watchlistService.js
@@ -1,0 +1,64 @@
+import { apiClient } from './apiClient'
+import { clientApiClient } from './clientApiClient'
+
+export const watchlistService = {
+  async createWatchlist(name) {
+    const { data } = await apiClient.post('/watchlists', { name })
+    return data
+  },
+  async listWatchlists() {
+    const { data } = await apiClient.get('/watchlists')
+    return data
+  },
+  async deleteWatchlist(id) {
+    const { data } = await apiClient.delete(`/watchlists/${id}`)
+    return data
+  },
+  async addItem(watchlistId, listingId) {
+    const { data } = await apiClient.post(`/watchlists/${watchlistId}/items`, { listing_id: listingId })
+    return data
+  },
+  async removeItem(watchlistId, listingId) {
+    const { data } = await apiClient.delete(`/watchlists/${watchlistId}/items/${listingId}`)
+    return data
+  },
+  async getItems(watchlistId) {
+    const { data } = await apiClient.get(`/watchlists/${watchlistId}/items`)
+    return data
+  },
+  async getQuick() {
+    const { data } = await apiClient.get('/watchlists/quick')
+    return data
+  },
+}
+
+export const clientWatchlistService = {
+  async createWatchlist(name) {
+    const { data } = await clientApiClient.post('/watchlists', { name })
+    return data
+  },
+  async listWatchlists() {
+    const { data } = await clientApiClient.get('/watchlists')
+    return data
+  },
+  async deleteWatchlist(id) {
+    const { data } = await clientApiClient.delete(`/watchlists/${id}`)
+    return data
+  },
+  async addItem(watchlistId, listingId) {
+    const { data } = await clientApiClient.post(`/watchlists/${watchlistId}/items`, { listing_id: listingId })
+    return data
+  },
+  async removeItem(watchlistId, listingId) {
+    const { data } = await clientApiClient.delete(`/watchlists/${watchlistId}/items/${listingId}`)
+    return data
+  },
+  async getItems(watchlistId) {
+    const { data } = await clientApiClient.get(`/watchlists/${watchlistId}/items`)
+    return data
+  },
+  async getQuick() {
+    const { data } = await clientApiClient.get('/watchlists/quick')
+    return data
+  },
+}


### PR DESCRIPTION
## Summary

- **FE-C4-01** Negotiation history timeline on OTC detail pages (employee + client portals) — action badges (CREATED / COUNTER OFFER / ACCEPTED / REJECTED) with colour coding, strikethrough for changed values, dark mode, Tailwind card design matching the rest of the page
- **FE-C4-02** Fund discovery table with 4 new sortable stat columns (Annual Return, Volatility, Max Drawdown, R/V Ratio); fund detail stat cards; dashed gray "Market Avg" line on the performance chart — both employee and client views

## Test plan

- [x] OTC negotiation detail (employee) shows history section with coloured badges below negotiation card
- [x] OTC negotiation detail (client) same
- [x] Funds discovery table shows 4 stat columns; N/A with tooltip when insufficient data; sorting pushes N/A funds to end
- [x] Fund detail page shows 4 stat cards beneath existing info cards
- [x] Fund detail performance chart renders dashed gray average line alongside fund line; updates when date range changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)